### PR TITLE
fixes integrate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,37 +16,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install fontconfig dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
-
-      - name: Install HDF5
+      - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libhdf5-dev
+          sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libhdf5-dev
 
-      - name: Set HDF5_DIR environment variable
+      - name: Set HDF5_DIR
         run: echo "HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial" >> $GITHUB_ENV
-
-      - name: Verify test files
-        run: |
-          ls -l tests/data/test_7_nt.fa || { echo "Error: test_7_nt.fa missing"; exit 1; }
-          ls -l tests/data/test_7_nt_long_id.fa || { echo "Error: test_7_nt_long_id.fa missing"; exit 1; }
 
       - name: Increase pipe buffer size
         run: sudo sysctl -w fs.pipe-max-size=1048576
 
-      - name: Clean target directory (force rebuild)
+      - name: Clean target
         run: rm -rf target
 
-      - name: Build
+      - name: Show CPU features (for debugging)
+        run: |
+          cat /proc/cpuinfo | grep -E 'flags|model name' | head -20
+          rustc --print cfg | grep target_feature
+
+      - name: Build with native CPU features
         run: cargo build --verbose
         env:
-          RUSTFLAGS: "-C target-cpu=haswell"
+          RUSTFLAGS: "-C target-cpu=native"
 
-      - name: Run tests
+      - name: Run tests with native features (AVX-512 when available)
         run: |
           RUST_BACKTRACE=full cargo test --verbose -- --test-threads=1
         env:
-          RUSTFLAGS: "-C target-cpu=haswell"
+          RUSTFLAGS: "-C target-cpu=native"
           CARGO_INCREMENTAL: "0"
           RUST_LOG: debug
+
+      # Optional: Explicit scalar-only test run (for extra safety)
+#      - name: Run tests with scalar-only (force no AVX-512)
+#        run: |
+#          RUST_BACKTRACE=full cargo test --verbose -- --test-threads=1
+#        env:
+#          RUSTFLAGS: "-C target-cpu=haswell"
+#          CARGO_INCREMENTAL: "0"
+#          RUST_LOG: debug

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ sysinfo = "0.37.0"
 futures = "0.3.31"
 tokio = { version = "1.44.2", features = ["full", "test-util"] }
 anyhow = "1.0.98"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [profile.release]
 lto = "fat"
@@ -65,3 +66,7 @@ path = "src/main.rs"
 [lib]
 name = "seqtoid_pipelines"
 path = "src/lib.rs"
+
+[[bench]]
+name = "avx512_parsers"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ regex = "1.12.2"
 once_cell = "1.21.3"
 async-stream = "0.3.6"
 nix = { version = "0.31.2", features = ["fs"] }
+which = "8.0.2"
 
 [dev-dependencies]
 sysinfo = "0.37.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ once_cell = "1.21.3"
 async-stream = "0.3.6"
 nix = { version = "0.31.2", features = ["fs"] }
 which = "8.0.2"
+proptest = "1.11.0"
 
 [dev-dependencies]
 sysinfo = "0.37.0"

--- a/benches/avx512_parsers.rs
+++ b/benches/avx512_parsers.rs
@@ -1,9 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use std::fs;
+use seqtoid_pipelines::utils::fastx::{fastx_generator, SequenceRecord, parse_header};
+use std::io::Cursor;
+use needletail::parser::FastqReader;
+use needletail::FastxReader;
 
 use seqtoid_pipelines::utils::blast::M8Record;
 use seqtoid_pipelines::utils::paf::PafRecord;
-use seqtoid_pipelines::utils::fastx::parse_header;
+
 
 // ── Existing micro benchmarks (kept for reference) ───────────────────────
 
@@ -156,6 +159,71 @@ fn bench_paf_large_batch_streaming(c: &mut Criterion) {
     group.finish();
 }
 
+
+fn generate_fastq_bytes(num_reads: usize, read_len: usize) -> Vec<u8> {
+    let mut buffer = Vec::with_capacity(num_reads * (read_len * 2 + 100));
+    for i in 0..num_reads {
+        let id = format!("read{}", i);
+        let seq = "ACGT".repeat(read_len / 4);
+        let qual = "IIII".repeat(read_len / 4);
+
+        buffer.extend_from_slice(b"@");
+        buffer.extend_from_slice(id.as_bytes());
+        buffer.extend_from_slice(b"\n");
+        buffer.extend_from_slice(seq.as_bytes());
+        buffer.extend_from_slice(b"\n+\n");
+        buffer.extend_from_slice(qual.as_bytes());
+        buffer.extend_from_slice(b"\n");
+    }
+    buffer
+}
+
+fn bench_read_ingestion_single_end(c: &mut Criterion) {
+    let fastq_data = generate_fastq_bytes(200_000, 150);
+    let data_len = fastq_data.len() as u64;
+
+    let mut group = c.benchmark_group("read_ingestion_single_end");
+    group.throughput(Throughput::Bytes(data_len));
+    group.sample_size(10);
+
+    group.bench_function("parse_fastq_to_sequence_record", |b| {
+        b.iter(|| {
+            let cursor = Cursor::new(black_box(&fastq_data));
+            let mut reader = FastqReader::new(cursor);
+            let mut count = 0u64;
+
+            while let Some(result) = reader.next() {
+                if let Ok(record) = result {
+                    let _seq_record: SequenceRecord = record.into(); // includes parse_header
+                    count += 1;
+                }
+            }
+            black_box(count)
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_read_ingestion_paired_end_compare_ids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_ingestion_paired_compare_ids");
+    group.sample_size(100);
+
+    let id1 = b"SRR12345678.1 1:N:0:ATCGATCG";
+    let id2 = b"SRR12345678.2 2:N:0:ATCGATCG";
+
+    group.bench_function("compare_read_ids_bytes", |b| {
+        b.iter(|| {
+            // Using the public wrapper for now
+            black_box(seqtoid_pipelines::utils::fastx::compare_read_ids(
+                black_box(std::str::from_utf8(id1).unwrap()),
+                black_box(std::str::from_utf8(id2).unwrap()),
+            ))
+        })
+    });
+
+    group.finish();
+}
 // ── Register all benchmarks ──────────────────────────────────────────────
 
 criterion_group!(
@@ -166,6 +234,8 @@ criterion_group!(
     bench_m8_nr_line,
     bench_m8_nt_large_batch_streaming,
     bench_paf_large_batch_streaming,
+    bench_read_ingestion_single_end,
+    bench_read_ingestion_paired_end_compare_ids,
 );
 
 criterion_main!(benches);

--- a/benches/avx512_parsers.rs
+++ b/benches/avx512_parsers.rs
@@ -1,0 +1,171 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use std::fs;
+
+use seqtoid_pipelines::utils::blast::M8Record;
+use seqtoid_pipelines::utils::paf::PafRecord;
+use seqtoid_pipelines::utils::fastx::parse_header;
+
+// ── Existing micro benchmarks (kept for reference) ───────────────────────
+
+fn bench_parse_header(c: &mut Criterion) {
+    let long_header: &[u8] = b"very_long_read_id_that_spans_multiple_64_byte_chunks_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx some description here";
+
+    let mut group = c.benchmark_group("parse_header");
+    group.throughput(Throughput::Bytes(long_header.len() as u64));
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| parse_header(black_box(long_header), '>'))
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| seqtoid_pipelines::utils::fastx::parse_header(black_box(long_header), '>'))
+    });
+    group.finish();
+}
+
+fn bench_paf_line(c: &mut Criterion) {
+    let line = "read1\t150\t0\t150\t+\tNC_045512.2\t29903\t100\t250\t148\t150\t60\tcg:Z:150M\tNM:i:0\tAS:i:300";
+
+    let mut group = c.benchmark_group("paf_single_line");
+    group.throughput(Throughput::Bytes(line.len() as u64));
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| PafRecord::parse_line_scalar(black_box(line)))
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| PafRecord::parse_line(black_box(line)))
+    });
+    group.finish();
+}
+
+fn bench_m8_nt_line(c: &mut Criterion) {
+    let line = "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\tAS:i:300\tNM:i:1";
+
+    let mut group = c.benchmark_group("m8_nt_single_line");
+    group.throughput(Throughput::Bytes(line.len() as u64));
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| M8Record::parse_line_nt_scalar(black_box(line)))
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| M8Record::parse_line_nt(black_box(line)))
+    });
+    group.finish();
+}
+
+fn bench_m8_nr_line(c: &mut Criterion) {
+    let line = "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000\tAS:i:180\tNM:i:3";
+
+    let mut group = c.benchmark_group("m8_nr_single_line");
+    group.throughput(Throughput::Bytes(line.len() as u64));
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| M8Record::parse_line_nr_scalar(black_box(line)))
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| M8Record::parse_line_nr(black_box(line)))
+    });
+    group.finish();
+}
+
+// ── NEW: Large-Batch Streaming Benchmarks ────────────────────────────────
+
+/// Generate a realistic large batch of NT M8 lines in memory (no disk I/O)
+fn generate_m8_nt_batch(count: usize) -> String {
+    let mut batch = String::with_capacity(count * 120);
+    for i in 0..count {
+        batch.push_str(&format!(
+            "read{}\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\n",
+            i
+        ));
+    }
+    batch
+}
+
+/// Generate a realistic large batch of PAF lines in memory
+fn generate_paf_batch(count: usize) -> String {
+    let mut batch = String::with_capacity(count * 110);
+    for i in 0..count {
+        batch.push_str(&format!(
+            "read{}\t150\t0\t150\t+\tNC_045512.2\t29903\t100\t250\t148\t150\t60\tcg:Z:150M\tNM:i:0\n",
+            i
+        ));
+    }
+    batch
+}
+
+fn bench_m8_nt_large_batch_streaming(c: &mut Criterion) {
+    // 500k lines ≈ realistic mNGS BLAST output size
+    let batch = generate_m8_nt_batch(500_000);
+    let bytes = batch.as_bytes();
+
+    let mut group = c.benchmark_group("m8_nt_large_batch_streaming");
+    group.throughput(Throughput::Bytes(bytes.len() as u64));
+    group.sample_size(10); // fewer samples because this is heavy
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| {
+            for line in bytes.split(|&c| c == b'\n') {
+                if line.is_empty() { continue; }
+                let _ = black_box(M8Record::parse_line_nt_scalar(std::str::from_utf8(line).unwrap()));
+            }
+        })
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| {
+            for line in bytes.split(|&c| c == b'\n') {
+                if line.is_empty() { continue; }
+                let _ = black_box(M8Record::parse_line_nt(std::str::from_utf8(line).unwrap()));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_paf_large_batch_streaming(c: &mut Criterion) {
+    let batch = generate_paf_batch(500_000);
+    let bytes = batch.as_bytes();
+
+    let mut group = c.benchmark_group("paf_large_batch_streaming");
+    group.throughput(Throughput::Bytes(bytes.len() as u64));
+    group.sample_size(10);
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| {
+            for line in bytes.split(|&c| c == b'\n') {
+                if line.is_empty() { continue; }
+                let _ = black_box(PafRecord::parse_line_scalar(std::str::from_utf8(line).unwrap()));
+            }
+        })
+    });
+
+    group.bench_function("dispatched", |b| {
+        b.iter(|| {
+            for line in bytes.split(|&c| c == b'\n') {
+                if line.is_empty() { continue; }
+                let _ = black_box(PafRecord::parse_line(std::str::from_utf8(line).unwrap()));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+// ── Register all benchmarks ──────────────────────────────────────────────
+
+criterion_group!(
+    benches,
+    bench_parse_header,
+    bench_paf_line,
+    bench_m8_nt_line,
+    bench_m8_nr_line,
+    bench_m8_nt_large_batch_streaming,
+    bench_paf_large_batch_streaming,
+);
+
+criterion_main!(benches);

--- a/benches/avx512_parsers.rs
+++ b/benches/avx512_parsers.rs
@@ -1,16 +1,28 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use seqtoid_pipelines::utils::fastx::{fastx_generator, SequenceRecord, parse_header};
+
 use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use needletail::parser::FastqReader;
 use needletail::FastxReader;
 use ahash::AHashMap;
 use dashmap::DashMap;
+use bytes::Bytes;
 
 
+use tokio::sync::{mpsc, Semaphore};
+use tokio_stream::wrappers::ReceiverStream;
+
+use seqtoid_pipelines::config::defs::{Taxid, Lineage, StreamDataType, RunConfig, SimdLevel, GpuDetection, NRAlignmentBackend};
+use seqtoid_pipelines::utils::fastx::{write_fasta_stream_to_file};
+use seqtoid_pipelines::utils::fastx::{fastx_generator, SequenceRecord, parse_header};
+use seqtoid_pipelines::utils::streams::{ParseOutput};
 use seqtoid_pipelines::utils::paf::PafRecord;
 use seqtoid_pipelines::utils::blast::{
-    process_record_pair, M8Record, AggBucket, merge_aggregations,
+    process_record_pair, M8Record, AggBucket, merge_aggregations, summarize_m8_hits, consensus_level
 };
+use seqtoid_pipelines::utils::taxonomy::{get_valid_lineage};
 
 
 
@@ -289,6 +301,315 @@ fn bench_blast_hit_processing(c: &mut Criterion) {
 
     group.finish();
 }
+
+// ── summarize_m8_hits (with inline helpers) ──────────────────────────────
+
+use fst::{Map, MapBuilder};
+use log::LevelFilter;
+use rayon::ThreadPoolBuilder;
+use seqtoid_pipelines::Arguments;
+use seqtoid_pipelines::utils::system::{detect_ram, generate_rng};
+
+fn lineage(species: i32, genus: i32, family: i32) -> Lineage {
+    [species, genus, family]
+}
+
+fn build_lineage_map() -> AHashMap<Taxid, Lineage> {
+    let mut map = AHashMap::default();
+    map.insert(1, lineage(1, 10, 100));
+    map.insert(2, lineage(2, 20, 200));
+    map.insert(3, lineage(3, 30, 300));
+    map.insert(4, lineage(1, 10, 999));
+    map
+}
+
+fn build_acc_map(entries: &[(&str, u64)]) -> Map<Vec<u8>> {
+    let mut builder = MapBuilder::memory();
+    for (k, v) in entries {
+        builder.insert(k.as_bytes(), *v).unwrap();
+    }
+    builder.into_map()
+}
+
+fn generate_hits_for_read(read_id: &str, num_hits: usize) -> Vec<M8Record> {
+    let mut hits = Vec::with_capacity(num_hits);
+    for i in 0..num_hits {
+        let bitscore = 300.0 - (i as f64 * 3.0);
+        hits.push(M8Record {
+            qname: read_id.to_string(),
+            tname: "QIK02963".to_string(),
+            pident: 87.5,
+            alen: 150 + i as u64,
+            mismatch: 12,
+            gapopen: 0,
+            qstart: 1,
+            qend: 150 + i as u64,
+            tstart: 1,
+            tend: 150 + i as u64,
+            evalue: 1.45e-38,
+            bitscore,
+            qlen: 0,
+            slen: 0,
+        });
+    }
+    hits
+}
+
+fn bench_summarize_m8_hits(c: &mut Criterion) {
+    let lineage_map = build_lineage_map();
+    let acc2taxid_map = build_acc_map(&[("QIK02963", 1)]);
+
+    let num_reads = 5_000; // Start smaller while testing
+    let mut all_reads = Vec::with_capacity(num_reads);
+
+    for i in 0..num_reads {
+        let read_id = format!("read{}", i);
+        let hits = generate_hits_for_read(&read_id, 8);
+        all_reads.push((i as u64, read_id, hits));
+    }
+
+    let mut group = c.benchmark_group("summarize_m8_hits");
+    group.throughput(Throughput::Elements(num_reads as u64));
+    group.sample_size(10);
+
+    group.bench_function("best_hit + consensus", |b| {
+        b.iter(|| {
+            for (seq, read_id, hits) in &all_reads {
+                let _ = black_box(summarize_m8_hits(
+                    black_box(*seq),
+                    black_box(read_id.clone()),
+                    black_box(hits),
+                    &lineage_map,
+                    &acc2taxid_map,
+                    &|_: &[i32]| true,
+                    black_box(50),
+                ));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+// ── parse_paf_batch_to_m8 ────────────────────────────────────────────────
+
+fn bench_parse_paf_batch_to_m8(c: &mut Criterion) {
+    // Start with 50k lines for faster iteration while developing.
+    // Increase to 200k–500k later for final measurements.
+    let batch = generate_paf_batch(50_000);
+    let bytes = batch.into_bytes();
+    let genome_size = 29903.0;
+
+    let mut group = c.benchmark_group("parse_paf_batch_to_m8");
+    group.throughput(Throughput::Bytes(bytes.len() as u64));
+    group.sample_size(10);
+
+    group.bench_function("full_batch_conversion", |b| {
+        b.iter(|| {
+            let _ = black_box(seqtoid_pipelines::utils::paf::parse_paf_batch_to_m8(
+                black_box(bytes.clone()),
+                genome_size,
+            ));
+        })
+    });
+
+    group.finish();
+}
+
+// ── generate_taxid_fasta Core Logic ──────────────────────────────────────
+
+fn bench_generate_taxid_fasta_core(c: &mut Criterion) {
+    let num_records = 10_000;
+    let mut records = Vec::with_capacity(num_records);
+
+    for i in 0..num_records {
+        records.push(SequenceRecord::Fasta {
+            id: format!(
+                "contig:family_nr:1:family_nt:2:genus_nr:10:genus_nt:20:species_nr:100:species_nt:200:read{}",
+                i
+            ),
+            desc: None,
+            seq: Bytes::from_static(b"ACGTACGTACGT"),
+        });
+    }
+
+    // Wrap maps in Arc to match the real function signature
+    let lineage_map: Arc<AHashMap<Taxid, Lineage>> = Arc::new(build_lineage_map());
+    let nt_hits: Arc<AHashMap<String, (Taxid, u8)>> = Arc::new(AHashMap::default());
+    let nr_hits: Arc<AHashMap<String, (Taxid, u8)>> = Arc::new(AHashMap::default());
+
+    let mut group = c.benchmark_group("generate_taxid_fasta_core");
+    group.throughput(Throughput::Elements(num_records as u64));
+    group.sample_size(10);
+
+    group.bench_function("parallel_annotation", |b| {
+        b.iter(|| {
+            for rec in &records {
+                let annotated_id = rec.id();
+                let parts: Vec<&str> = annotated_id.split(':').collect();
+                let contig_id = parts.last().unwrap_or(&"").to_string();
+
+                // Now passing &Arc<...> as expected by get_valid_lineage
+                let _nr_lineage = get_valid_lineage(&nr_hits, &lineage_map, &contig_id);
+                let _nt_lineage = get_valid_lineage(&nt_hits, &lineage_map, &contig_id);
+
+                let new_header = format!(
+                    "family_nr:1:family_nt:2:genus_nr:10:genus_nt:20:species_nr:100:species_nt:200:{}",
+                    annotated_id
+                );
+                let _ = black_box(parse_header(new_header.as_bytes(), '>'));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+// ── generate_taxid_locator Core ──────────────────────────────────────────
+
+fn bench_generate_taxid_locator_core(c: &mut Criterion) {
+    let num_records = 20_000;
+    let mut records = Vec::with_capacity(num_records);
+
+    for i in 0..num_records {
+        records.push(SequenceRecord::Fasta {
+            id: format!("family_nr:1:family_nt:2:read{}", i),
+            desc: None,
+            seq: Bytes::from_static(b"ACGT"),
+        });
+    }
+
+    let mut group = c.benchmark_group("generate_taxid_locator_core");
+    group.throughput(Throughput::Elements(num_records as u64));
+    group.sample_size(10);
+
+    group.bench_function("record_distribution", |b| {
+        b.iter(|| {
+            // Simulate the broadcast logic to multiple taxid channels
+            for rec in &records {
+                let header = rec.id().to_string();
+                // In real code this goes to multiple channels based on taxid_field
+                black_box(header);
+            }
+        })
+    });
+
+    group.finish();
+}
+
+// ── consensus_level under high load ──────────────────────────────────────
+
+// ── consensus_level under high hit counts ─────────────────────────────────
+
+fn bench_consensus_level_high_load(c: &mut Criterion) {
+    let num_hits = 200;
+    let mut hits = Vec::with_capacity(num_hits);
+
+    for i in 0..num_hits {
+        hits.push(M8Record {
+            qname: "read1".to_string(),
+            tname: format!("QIK02963.{}", i), // realistic accession style
+            pident: 85.0 + (i as f64 % 10.0),
+            alen: 120,
+            mismatch: 10,
+            gapopen: 1,
+            qstart: 1,
+            qend: 120,
+            tstart: 1,
+            tend: 120,
+            evalue: 1e-30,
+            bitscore: 250.0,
+            qlen: 150,
+            slen: 300,
+        });
+    }
+
+    let lineage_map = build_lineage_map();
+    let acc2taxid_map = build_acc_map(&[("QIK02963", 1)]);
+
+    // Required 4th argument
+    let should_keep = Arc::new(|_: &[i32]| true);
+
+    let mut group = c.benchmark_group("consensus_level_high_load");
+    group.throughput(Throughput::Elements(num_hits as u64));
+    group.sample_size(10);
+
+    group.bench_function("200_hits", |b| {
+        b.iter(|| {
+            let _ = black_box(consensus_level(
+                black_box(&hits),
+                black_box(&lineage_map),
+                black_box(&acc2taxid_map),
+                black_box(&should_keep),
+            ));
+        })
+    });
+
+    group.finish();
+}
+
+
+// ── Buffer & Concurrency Tuning Functions ────────────────────────────────
+
+fn bench_compute_buffer_and_concurrency(c: &mut Criterion) {
+    let args = Arguments {
+        threads: 8,
+        ..Default::default()
+    };
+    let (total_ram, available_ram) = detect_ram()
+        .unwrap_or((16u64 << 30, 8u64 << 30));
+
+    let rng = generate_rng(Some(42));
+
+    let mut config = RunConfig {
+        cwd: PathBuf::from("."),
+        ram_temp_dir: std::env::temp_dir(),
+        out_dir: PathBuf::from("test"),
+        args,
+        thread_pool: Arc::new(ThreadPoolBuilder::new().num_threads(8).build().unwrap()),
+        maximal_semaphore: Arc::new(Semaphore::new(8)),
+        base_buffer_size: 0,                    // temporary placeholder
+        input_size: 100 + 1_048_576,
+        physical_cores: 4,
+        max_cores: 32,
+        available_ram,
+        rng,
+        log_level: LevelFilter::Debug,
+        base_backpressure_pause: 1000,
+        simd: SimdLevel::Scalar,
+        gpu_info: GpuDetection { count: 0, gpus: vec![] },
+        has_gpu: false,
+        alignment_backend: NRAlignmentBackend::Diamond,
+    };
+
+    let mut group = c.benchmark_group("compute_buffer_concurrency");
+
+    group.bench_function("compute_buffer_size", |b| {
+        b.iter(|| {
+            black_box(seqtoid_pipelines::utils::system::compute_buffer_size(
+                black_box(&config),
+                "benchmark_phase",
+                StreamDataType::IlluminaFastq,
+                1.5,
+            ))
+        })
+    });
+
+    group.bench_function("compute_phase_concurrency", |b| {
+        b.iter(|| {
+            black_box(seqtoid_pipelines::utils::system::compute_phase_concurrency(
+                black_box(&config),
+                "benchmark_phase",
+                0.5,  // GB per thread
+                4.0,  // threads per core
+                128,  // max
+                8,    // min
+            ))
+        })
+    });
+
+    group.finish();
+}
 // ── Register all benchmarks ──────────────────────────────────────────────
 
 criterion_group!(
@@ -302,6 +623,12 @@ criterion_group!(
     bench_read_ingestion_single_end,
     bench_read_ingestion_paired_end_compare_ids,
     bench_blast_hit_processing,
+    bench_summarize_m8_hits,
+    bench_parse_paf_batch_to_m8,
+    bench_generate_taxid_fasta_core,
+    bench_generate_taxid_locator_core,
+    bench_consensus_level_high_load,
+    bench_compute_buffer_and_concurrency
 );
 
 criterion_main!(benches);

--- a/benches/avx512_parsers.rs
+++ b/benches/avx512_parsers.rs
@@ -3,9 +3,15 @@ use seqtoid_pipelines::utils::fastx::{fastx_generator, SequenceRecord, parse_hea
 use std::io::Cursor;
 use needletail::parser::FastqReader;
 use needletail::FastxReader;
+use ahash::AHashMap;
+use dashmap::DashMap;
 
-use seqtoid_pipelines::utils::blast::M8Record;
+
 use seqtoid_pipelines::utils::paf::PafRecord;
+use seqtoid_pipelines::utils::blast::{
+    process_record_pair, M8Record, AggBucket, merge_aggregations,
+};
+
 
 
 // ── Existing micro benchmarks (kept for reference) ───────────────────────
@@ -224,6 +230,65 @@ fn bench_read_ingestion_paired_end_compare_ids(c: &mut Criterion) {
 
     group.finish();
 }
+
+// ── BLAST Hit Processing Stage Benchmark ─────────────────────────────────
+
+fn generate_m8_and_hit_lines(count: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut pairs = Vec::with_capacity(count);
+
+    for i in 0..count {
+        // Realistic M8 line (NR-style)
+        let m8 = format!(
+            "read{}\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000\n",
+            i
+        );
+
+        // Realistic hit summary line (from kraken-style or your hit summary)
+        let hit = format!("read{}\t1\t12345\t1\t10\t100\t100\n", i);
+
+        pairs.push((m8.into_bytes(), hit.into_bytes()));
+    }
+    pairs
+}
+
+fn bench_blast_hit_processing(c: &mut Criterion) {
+    // 100k record pairs is a realistic batch size for benchmarking
+    let pairs = generate_m8_and_hit_lines(100_000);
+    let data_size: u64 = pairs.iter().map(|(m, h)| (m.len() + h.len()) as u64).sum();
+
+    let mut group = c.benchmark_group("blast_hit_processing_stage");
+    group.throughput(Throughput::Bytes(data_size));
+    group.sample_size(10);
+
+    group.bench_function("process_record_pair + aggregation", |b| {
+        b.iter(|| {
+            let mut agg: AHashMap<Vec<i32>, AggBucket> = AHashMap::default();
+            let mut lineage_cache: AHashMap<i32, Vec<i32>> = AHashMap::default();
+            let duplicate_clusters: DashMap<String, seqtoid_pipelines::config::defs::ClusterInfo> =
+                DashMap::new();
+
+            let should_keep = |_: &[i32]| true;
+
+            for (m8_bytes, hit_bytes) in &pairs {
+                let _ = process_record_pair(
+                    black_box(m8_bytes),
+                    black_box(hit_bytes),
+                    &mut agg,
+                    &mut lineage_cache,
+                    &duplicate_clusters,
+                    &should_keep,
+                    "NT",
+                    None,
+                );
+            }
+
+            // Also exercise merge_aggregations (common in real pipelines)
+            let _merged = merge_aggregations(vec![agg]);
+        })
+    });
+
+    group.finish();
+}
 // ── Register all benchmarks ──────────────────────────────────────────────
 
 criterion_group!(
@@ -236,6 +301,7 @@ criterion_group!(
     bench_paf_large_batch_streaming,
     bench_read_ingestion_single_end,
     bench_read_ingestion_paired_end_compare_ids,
+    bench_blast_hit_processing,
 );
 
 criterion_main!(benches);

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -5434,6 +5434,7 @@ pub async fn summarize_hits(
 /// # Arguments
 /// # Returns
 /// Result
+
 async fn write_empty_blast_outputs(
     blast_m8: &PathBuf,
     blast_top_m8: &PathBuf,
@@ -5442,13 +5443,21 @@ async fn write_empty_blast_outputs(
     refined_counts_with_dcr: &PathBuf,
     contig_summary_json: &PathBuf,
 
+    // These are the files we copy forward (same as Python)
+    deduped_m8: &PathBuf,
+    hit_summary: &PathBuf,
+    orig_counts_with_dcr: &PathBuf,
 ) -> Result<()> {
     tokio::fs::write(blast_m8, b" ").await?;
     tokio::fs::write(blast_top_m8, b" ").await?;
-    tokio::fs::write(refined_m8, b" ").await?;
-    tokio::fs::write(refined_hit_summary, b" ").await?;
-    tokio::fs::write(refined_counts_with_dcr, b" ").await?;
+
+    // Preserve previous read-level results (critical)
+    tokio::fs::copy(deduped_m8, refined_m8).await?;
+    tokio::fs::copy(hit_summary, refined_hit_summary).await?;
+    tokio::fs::copy(orig_counts_with_dcr, refined_counts_with_dcr).await?;
+
     tokio::fs::write(contig_summary_json, b"[]").await?;
+
     Ok(())
 }
 
@@ -6021,6 +6030,77 @@ pub async fn generate_m8_and_hit_summary(
 }
 
 
+
+async fn early_blast_exit(
+    db_type: &str,
+    blast_m8: &PathBuf,
+    blast_top_m8: &PathBuf,
+    refined_m8: &PathBuf,
+    refined_hit_summary: &PathBuf,
+    refined_counts: &PathBuf,
+    contig_summary: &PathBuf,
+    deduped_m8: Option<&PathBuf>,
+    hit_summary: Option<&PathBuf>,
+    orig_counts: Option<&PathBuf>,
+    read_dict: &Arc<Mutex<AHashMap<String, Arc<ReadHit>>>>,
+    taxon_counts: Vec<TaxonCount>,
+    fn_start: tokio::time::Instant,
+) -> Result<(
+    AHashMap<String, Arc<ReadHit>>,
+    Vec<TaxonCount>,
+    Vec<ContigSummaryEntry>,
+    mpsc::Receiver<ParseOutput>,
+    mpsc::Receiver<ParseOutput>,
+    mpsc::Receiver<ParseOutput>,
+    Vec<JoinHandle<Result<()>>>,
+    Vec<oneshot::Receiver<Result<()>>>,
+    Vec<NamedTempFile>,
+)> {
+    warn!("[blast_contigs:{}] graceful early exit (no usable BLAST results)", db_type);
+
+    if let (Some(d), Some(h), Some(c)) = (deduped_m8, hit_summary, orig_counts) {
+        // Preserve previous read-level results (preferred path)
+        tokio::fs::write(blast_m8, b" ").await?;
+        tokio::fs::write(blast_top_m8, b" ").await?;
+        tokio::fs::copy(d, refined_m8).await?;
+        tokio::fs::copy(h, refined_hit_summary).await?;
+        tokio::fs::copy(c, refined_counts).await?;
+        tokio::fs::write(contig_summary, b"[]").await?;
+    } else {
+        // Fallback when we don't have the source files (current streaming situation)
+        tokio::fs::write(blast_m8, b" ").await?;
+        tokio::fs::write(blast_top_m8, b" ").await?;
+        tokio::fs::write(refined_m8, b" ").await?;
+        tokio::fs::write(refined_hit_summary, b" ").await?;
+        tokio::fs::write(refined_counts, b" ").await?;
+        tokio::fs::write(contig_summary, b"[]").await?;
+    }
+
+    let final_read_dict = read_dict.lock().unwrap().clone();
+    let (_m8_tx, m8_rx) = mpsc::channel(1);
+    let (_hit_tx, hit_rx) = mpsc::channel(1);
+    let (_top_tx, top_rx) = mpsc::channel(1);
+
+    info!(
+        "[blast_contigs:{}] empty-output fast path complete after {:?}",
+        db_type,
+        fn_start.elapsed()
+    );
+
+    Ok((
+        final_read_dict,
+        taxon_counts,
+        vec![],
+        m8_rx,
+        hit_rx,
+        top_rx,
+        vec![],
+        vec![],
+        vec![],
+    ))
+}
+
+// ====================== blast_contigs ======================
 pub async fn blast_contigs(
     config: Arc<RunConfig>,
     db_type: &'static str,
@@ -6048,7 +6128,7 @@ pub async fn blast_contigs(
     Vec<oneshot::Receiver<Result<()>>>,
     Vec<NamedTempFile>,
 )> {
-    use std::time::{Duration, Instant};
+    use tokio::time::Instant;           // ← use tokio's Instant
 
     let fn_start = Instant::now();
     info!(
@@ -6099,50 +6179,121 @@ pub async fn blast_contigs(
         ref_size
     );
 
-    if contig_size < MIN_REF_FASTA_SIZE || ref_size < MIN_ASSEMBLED_CONTIG_SIZE {
-        warn!(
-            "[blast_contigs:{}] skipping BLAST: contig_size={} ref_size={} (thresholds contig>= {}, ref>= {})",
+    // ─────────────────────────────────────────────────────────────
+    // Graceful early exit if there is nothing useful to BLAST
+    // ─────────────────────────────────────────────────────────────
+    if contig_size < MIN_ASSEMBLED_CONTIG_SIZE || ref_size < MIN_REF_FASTA_SIZE {
+        return early_blast_exit(
             db_type,
-            contig_size,
-            ref_size,
-            MIN_REF_FASTA_SIZE,
-            MIN_ASSEMBLED_CONTIG_SIZE
-        );
-
-        write_empty_blast_outputs(
             &blast_m8_path,
             &blast_top_m8_path,
             &refined_m8_path,
             &refined_hit_summary_path,
             &refined_counts_path,
             &contig_summary_path,
+            None,
+            None,
+            None,
+            &read_dict,
+            taxon_counts,
+            fn_start,
         )
-            .await?;
+            .await;
+    }
 
-        let final_read_dict = read_dict.lock().unwrap().clone();
+    // ─────────────────────────────────────────────────────────────
+    // Normal path
+    // ─────────────────────────────────────────────────────────────
+    let temp_dir = choose_temp_dir(
+        ref_size + contig_size,
+        &config.ram_temp_dir,
+        &config.args.nvme_scratch,
+        blast_headroom,
+        true,
+    )
+        .await?;
+    info!(
+        "[blast_contigs:{}] temp dir chosen: {}",
+        db_type,
+        temp_dir.path().display()
+    );
 
-        let (_m8_tx, m8_rx) = mpsc::channel(1);
-        let (_hit_tx, hit_rx) = mpsc::channel(1);
-        let (_top_tx, top_rx) = mpsc::channel(1);
+    let blastdb_suffix = format!("{}_blastindex", db_type);
+    let blastdb_ram_path = NamedTempFile::with_suffix_in(blastdb_suffix, &temp_dir)
+        .map_err(|e| PipelineError::Other(e.into()))?;
+    let blastdb_path = blastdb_ram_path.path().to_owned();
+    temp_files.push(blastdb_ram_path);
 
-        info!(
-            "[blast_contigs:{}] empty-output fast path complete after {:?}",
-            db_type,
-            fn_start.elapsed()
+    info!(
+        "[blast_contigs:{}] blastdb path: {}",
+        db_type,
+        blastdb_path.display()
+    );
+
+    let makeblastdb_config = MakeblastdbConfig {
+        input: reference_fasta.clone(),
+        dbtype: if db_type == NT_TAG {
+            "nucl".to_string()
+        } else {
+            "prot".to_string()
+        },
+        output: blastdb_path.clone(),
+        option_fields: HashMap::new(),
+    };
+
+    let makeblastdb_args = generate_cli(MAKEBLASTDB_TAG, &config, Some(&makeblastdb_config))
+        .map_err(|e| PipelineError::ToolExecution {
+            tool: MAKEBLASTDB_TAG.to_string(),
+            error: e.to_string(),
+        })?;
+
+    info!("[blast_contigs:{}] launching makeblastdb", db_type);
+
+    let (mut makeblastdb_child, makeblastdb_err_task) = spawn_cmd(
+        config.clone(),
+        MAKEBLASTDB_TAG,
+        makeblastdb_args,
+        config.args.verbose,
+        None
+    )
+        .await?;
+
+    makeblastdb_child.wait().await.map_err(|e| PipelineError::ToolExecution {
+        tool: MAKEBLASTDB_TAG.to_string(),
+        error: format!("makeblastdb failed: {}", e),
+    })?;
+    makeblastdb_err_task.await??;
+
+    let index_ext = if db_type == NT_TAG { "nal" } else { "pal" };
+    let expected_index = blastdb_path.with_extension(index_ext);
+
+    if !expected_index.exists() {
+        warn!(
+            "[blast_contigs:{}] makeblastdb did not produce expected index at {}. Falling back gracefully.",
+            db_type, expected_index.display()
         );
 
-        return Ok((
-            final_read_dict,
+        return early_blast_exit(
+            db_type,
+            &blast_m8_path,
+            &blast_top_m8_path,
+            &refined_m8_path,
+            &refined_hit_summary_path,
+            &refined_counts_path,
+            &contig_summary_path,
+            None,
+            None,
+            None,
+            &read_dict,
             taxon_counts,
-            vec![],
-            m8_rx,
-            hit_rx,
-            top_rx,
-            cleanup_tasks,
-            cleanup_receivers,
-            temp_files,
-        ));
+            fn_start,
+        )
+            .await;
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Index exists → continue with blastn/x
+    // ─────────────────────────────────────────────────────────────
 
     let temp_dir = choose_temp_dir(
         ref_size + contig_size,
@@ -6187,11 +6338,7 @@ pub async fn blast_contigs(
             error: e.to_string(),
         })?;
 
-    info!(
-        "[blast_contigs:{}] launching {}",
-        db_type, MAKEBLASTDB_TAG
-    );
-
+    info!("[blast_contigs:{}] launching makeblastdb", db_type);
 
     let (mut makeblastdb_child, makeblastdb_err_task) = spawn_cmd(
         config.clone(),
@@ -6202,22 +6349,45 @@ pub async fn blast_contigs(
     )
         .await?;
 
-    // Wait for makeblastdb to fully finish creating the index files
+    // Wait for makeblastdb to finish
     makeblastdb_child.wait().await.map_err(|e| PipelineError::ToolExecution {
         tool: MAKEBLASTDB_TAG.to_string(),
         error: format!("makeblastdb failed: {}", e),
     })?;
     makeblastdb_err_task.await??;
 
-    // Verify the index was actually created (BLAST looks for the .nal/.pal alias file)
+    // Verify the index was created
     let index_ext = if db_type == NT_TAG { "nal" } else { "pal" };
     let expected_index = blastdb_path.with_extension(index_ext);
+
     if !expected_index.exists() {
-        return Err(anyhow!(
-        "makeblastdb did not produce index file at {}",
-        expected_index.display()
-    ));
+        warn!(
+        "[blast_contigs:{}] makeblastdb did not produce expected index at {}. Falling back gracefully.",
+        db_type, expected_index.display()
+    );
+
+        return early_blast_exit(
+            db_type,
+            &blast_m8_path,
+            &blast_top_m8_path,
+            &refined_m8_path,
+            &refined_hit_summary_path,
+            &refined_counts_path,
+            &contig_summary_path,
+            None,
+            None,
+            None,
+            &read_dict,
+            taxon_counts,
+            fn_start,
+        )
+            .await;           // ← add this
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // If we reach here, the index exists — continue with blastn/x
+    // (rest of the function stays the same)
+    // ─────────────────────────────────────────────────────────────
 
     let blast_command = if db_type == NT_TAG {
         BLASTN_TAG

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -160,13 +160,10 @@ pub struct AssemblyHandle {
 #[derive(Debug)]
 pub struct CoverageOutputs {
     pub contigs_fasta: PathBuf,
-    pub contigs_ram_fasta: PathBuf,
     pub contigs_all_fasta: PathBuf,
     pub scaffolds_fasta: PathBuf,
-    pub sam_path: PathBuf,
+    pub bam_path: PathBuf,
     pub contig_stats_json: PathBuf,
-    pub coverage_json: PathBuf,
-    pub coverage_summary_csv: PathBuf,
     pub contig_stats: Arc<HashMap<String, u64>>,
     pub read2contig: Arc<HashMap<String, String>>,
 }
@@ -4236,189 +4233,12 @@ async fn write_dummy_assembly_files(assembly_dir: &PathBuf) -> Result<(), anyhow
 /// * `input_stream` - Raw byte FASTQ stream
 ///
 /// # Returns
-
-async fn spades_assembly(
-    config: Arc<RunConfig>,
-    r1_path: PathBuf,
-    r2_path_opt: Option<PathBuf>,
-    out_dir: &PathBuf,
-) -> Result<JoinHandle<Result<()>>> {
-    let assembly_dir = out_dir.join("assembly");
-    fs::create_dir_all(&assembly_dir)
-        .await
-        .map_err(|e| PipelineError::Other(anyhow!("Failed to create assembly dir: {}", e)))?;
-
-    let spades_task = tokio::spawn(async move {
-        let mut cleanup_tasks = Vec::new();
-
-        // 1. Temp dir
-        let est_temp_bytes = config.input_size + MAX_SPADES_WORK_DIR;
-        let temp_dir = choose_temp_dir(
-            est_temp_bytes,
-            &config.ram_temp_dir,
-            &config.args.nvme_scratch,
-            4,
-            true,
-        )
-            .await?;
-
-        // 2. Run SPAdes inside a dedicated work dir under the temp dir
-        let spades_work_dir = TempDir::new_in(&temp_dir)?;
-        let spades_work_path = spades_work_dir.path().to_path_buf();
-        let stdout_log_path = assembly_dir.join("spades_stdout.log");
-
-        info!(
-            "[spades] starting: r1={}, r2={:?}, assembly_dir={}, temp_dir={}, spades_work_path={}, input_size={}, est_temp_bytes={}",
-            r1_path.display(),
-            r2_path_opt.as_ref().map(|p| p.display().to_string()),
-            assembly_dir.display(),
-            temp_dir.path().display(),
-            spades_work_path.display(),
-            config.input_size,
-            est_temp_bytes
-        );
-
-        info!(
-            "[spades] temp/work dir exists before spawn: temp_dir_exists={}, spades_work_exists={}",
-            temp_dir.path().exists(),
-            spades_work_path.exists()
-        );
-
-        let mut options = HashMap::new();
-        options.insert("--only-assembler".to_string(), None);
-
-        let spades_config = SpadesConfig {
-            r1_path: r1_path.clone(),
-            r2_path_opt: r2_path_opt.clone(),
-            outdir_path: spades_work_path.clone(),
-            option_fields: options,
-        };
-
-        let spades_args = generate_cli(SPADES_TAG, &config, Some(&spades_config))?;
-
-        info!("[spades] command args: {:?}", spades_args);
-
-        let (mut spades_child, spades_stderr_task) = spawn_cmd(
-            config.clone(),
-            SPADES_TAG,
-            spades_args,
-            config.args.verbose,
-            None
-        )
-            .await?;
-
-        info!(
-            "[spades] child spawned: stdout_present={}, stderr_present={}",
-            spades_child.stdout.is_some(),
-            spades_child.stderr.is_some()
-        );
-
-        let spades_out_stream = parse_child_output(
-            &mut spades_child,
-            ChildStream::Stdout,
-            ParseMode::Lines,
-            &config,
-        )
-            .await
-            .map_err(|e| PipelineError::ToolExecution {
-                tool: SPADES_TAG.to_string(),
-                error: e.to_string(),
-            })?;
-
-        let spades_write_task = tokio::spawn(stream_to_file(
-            spades_out_stream,
-            stdout_log_path.clone(),
-        ));
-        cleanup_tasks.push(spades_write_task);
-
-        // stderr is drained and logged by spawn_cmd's internal stderr task
-        spades_stderr_task.await??;
-
-        // Check SPAdes exit
-        let spades_exit = spades_child.wait().await?;
-
-        info!(
-            "[spades] exit status={:?} success={} work_dir_exists_after_wait={} stdout_log={}",
-            spades_exit.code(),
-            spades_exit.success(),
-            spades_work_path.exists(),
-            stdout_log_path.display()
-        );
-
-        match fs::metadata(&stdout_log_path).await {
-            Ok(meta) => info!(
-                "[spades] stdout log written: {} bytes at {}",
-                meta.len(),
-                stdout_log_path.display()
-            ),
-            Err(e) => warn!(
-                "[spades] stdout log missing or unreadable at {}: {}",
-                stdout_log_path.display(),
-                e
-            ),
-        }
-
-        if !spades_exit.success() {
-            error!("SPAdes failed with exit: {:?}", spades_exit);
-
-            // Write dummies so downstream code can detect the failure cleanly.
-            let contigs_path = assembly_dir.join("contigs.fasta");
-            let contigs_all_path = assembly_dir.join("contigs_all.fasta");
-            let scaffolds_path = assembly_dir.join("scaffolds.fasta");
-            let sam_path = assembly_dir.join("read-contig.sam");
-            let failed_marker = b";ASSEMBLY FAILED\n";
-
-            tokio::fs::write(&contigs_path, failed_marker).await?;
-            tokio::fs::write(&contigs_all_path, failed_marker).await?;
-            tokio::fs::write(&scaffolds_path, failed_marker).await?;
-            tokio::fs::write(&sam_path, b"@NO INFO\n").await?;
-
-            info!(
-                "[spades] wrote dummy outputs after failure: contigs={}, contigs_all={}, scaffolds={}, sam={}",
-                contigs_path.display(),
-                contigs_all_path.display(),
-                scaffolds_path.display(),
-                sam_path.display()
-            );
-
-            return Err(anyhow!("SPAdes assembly failed"));
-        }
-
-        // Probe the expected SPAdes outputs before leaving this stage.
-        let contigs_path = spades_work_path.join("contigs.fasta");
-        let scaffolds_path = spades_work_path.join("scaffolds.fasta");
-        let sam_path = spades_work_path.join("read-contig.sam");
-
-        for p in [&contigs_path, &scaffolds_path, &sam_path] {
-            match fs::metadata(p).await {
-                Ok(meta) => info!(
-                    "[spades] output exists: {} ({} bytes)",
-                    p.display(),
-                    meta.len()
-                ),
-                Err(e) => warn!(
-                    "[spades] expected output missing: {} ({})",
-                    p.display(),
-                    e
-                ),
-            }
-        }
-
-        info!("SPAdes completed successfully");
-
-        Ok(())
-    });
-
-    Ok(spades_task)
-}
-
 pub async fn process_assembly(
     config: Arc<RunConfig>,
-    out_dir: &PathBuf,
-    work_dir: &PathBuf,
+    assembly_out_dir: &PathBuf,   // to make clear this is <out_dir>/assembly
     r1_path: PathBuf,
     r2_path_opt: Option<PathBuf>,
-    duplicate_clusters: Arc<DashMap<String, ClusterInfo>>,   // ← changed to DashMap
+    duplicate_clusters: Arc<DashMap<String, ClusterInfo>>,
     paired: bool,
     assembly_headroom: u64,
 ) -> Result<(
@@ -4427,203 +4247,208 @@ pub async fn process_assembly(
     Vec<JoinHandle<Result<()>>>,
     Vec<oneshot::Receiver<Result<()>>>,
     Vec<NamedTempFile>,
+    TempDir,
 ), PipelineError> {
     let mut cleanup_tasks = Vec::new();
     let cleanup_receivers = Vec::new();
     let mut temp_files: Vec<NamedTempFile> = Vec::new();
 
-    let raw_contigs_path = work_dir.join("contigs.fasta");
-    let raw_scaffolds_path = work_dir.join("scaffolds.fasta");
-    let (empty_tx, empty_rx) = mpsc::channel::<ParseOutput>(1);
-    drop(empty_tx);
 
-    info!(
-        "[assembly] process_assembly starting: out_dir={}, work_dir={}, raw_contigs={}, raw_scaffolds={}, paired={}",
-        out_dir.display(),
-        work_dir.display(),
-        raw_contigs_path.display(),
-        raw_scaffolds_path.display(),
-        paired
-    );
-
-    match fs::metadata(&raw_contigs_path).await {
-        Ok(meta) => info!(
-            "[assembly] raw contigs metadata before decision: exists=true size={} bytes is_file={}",
-            meta.len(),
-            meta.is_file()
-        ),
-        Err(e) => warn!(
-            "[assembly] raw contigs metadata before decision: exists=false path={} err={}",
-            raw_contigs_path.display(),
-            e
-        ),
-    }
-
-    match fs::metadata(&raw_scaffolds_path).await {
-        Ok(meta) => info!(
-            "[assembly] raw scaffolds metadata before decision: exists=true size={} bytes is_file={}",
-            meta.len(),
-            meta.is_file()
-        ),
-        Err(e) => warn!(
-            "[assembly] raw scaffolds metadata before decision: exists=false path={} err={}",
-            raw_scaffolds_path.display(),
-            e
-        ),
-    }
-
-    let spades_success = async {
-        match fs::metadata(&raw_contigs_path).await {
-            Ok(meta) => meta.len() > 0 && meta.is_file(),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
-            Err(e) => {
-                warn!("Failed to read contigs.fasta metadata: {}", e);
-                false
-            }
-        }
-    }
-        .await;
-
-    if !spades_success {
-        let reason = match fs::metadata(&raw_contigs_path).await {
-            Ok(meta) if meta.len() == 0 => "contigs.fasta is empty",
-            Ok(_) => "contigs.fasta exists but is not a usable file",
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => "contigs.fasta does not exist",
-            Err(e) => {
-                warn!(
-                    "[assembly] contigs.fasta metadata error at failure check: {}",
-                    e
-                );
-                "contigs.fasta metadata could not be read"
-            }
-        };
-
-        warn!(
-            "SPAdes assembly failed: {} — writing dummy outputs and skipping contig-based refinement",
-            reason
-        );
-
-        let dummy = ";ASSEMBLY FAILED";
-        let empty_sam = "@NO INFO\n";
-        let empty_json = "{}";
-
-        fs::write(out_dir.join("contigs.fasta"), dummy).await?;
-        fs::write(out_dir.join("contigs.ram.fasta"), dummy).await?;
-        fs::write(out_dir.join("contigs_all.fasta"), dummy).await?;
-        fs::write(out_dir.join("scaffolds.fasta"), dummy).await?;
-        fs::write(out_dir.join("read-contig.sam"), empty_sam).await?;
-        fs::write(out_dir.join("contig_stats.json"), empty_json).await?;
-
-        info!(
-            "[assembly] dummy outputs written to {}; no contig-based refinement will run",
-            out_dir.display()
-        );
-
-        return Ok((
-            CoverageOutputs {
-                contigs_fasta: out_dir.join("contigs.fasta"),
-                contigs_ram_fasta: out_dir.join("contigs.ram.fasta"),
-                contigs_all_fasta: out_dir.join("contigs_all.fasta"),
-                scaffolds_fasta: out_dir.join("scaffolds.fasta"),
-                sam_path: out_dir.join("read-contig.sam"),
-                contig_stats_json: out_dir.join("contig_stats.json"),
-                coverage_json: out_dir.join("assembly_contig_coverage.json"),
-                coverage_summary_csv: out_dir.join("assembly_contig_coverage_summary.csv"),
-                contig_stats: Arc::new(HashMap::new()),
-                read2contig: Arc::new(HashMap::new()),
-            },
-            ReceiverStream::new(empty_rx),
-            cleanup_tasks,
-            cleanup_receivers,
-            temp_files,
-        ));
-    }
-
-    let contigs_all_out = out_dir.join("contigs_all.fasta");
-    fs::copy(&raw_contigs_path, &contigs_all_out).await?;
-    info!(
-        "[assembly] copied raw contigs to contigs_all: {} -> {}",
-        raw_contigs_path.display(),
-        contigs_all_out.display()
-    );
-
-    let contigs_out = out_dir.join("contigs.fasta");
-    let contigs_size = file_size(&raw_contigs_path).await?;
-    info!(
-        "[assembly] raw contigs size: {} bytes ({} GiB)",
-        contigs_size,
-        contigs_size as f64 / 1_073_741_824.0
-    );
-
+    let est_temp_bytes = config.input_size + MAX_SPADES_WORK_DIR;
     let temp_dir = choose_temp_dir(
-        contigs_size,
+        est_temp_bytes,
         &config.ram_temp_dir,
         &config.args.nvme_scratch,
         assembly_headroom,
-        false,
+        true,
+    )
+        .await?;
+
+
+    let stdout_log_path = assembly_out_dir.join("spades_stdout.log");
+
+    info!(
+        "[spades] starting: r1={}, r2={:?}, final_assembly_dir={},  temp_dir={}",
+        r1_path.display(),
+        r2_path_opt.as_ref().map(|p| p.display().to_string()),
+        assembly_out_dir.display(),
+        temp_dir.path().to_path_buf().display(),
+    );
+
+    let mut options = HashMap::new();
+    options.insert("--only-assembler".to_string(), None);
+
+    let spades_config = SpadesConfig {
+        r1_path: r1_path.clone(),
+        r2_path_opt: r2_path_opt.clone(),
+        outdir_path: temp_dir.path().to_path_buf(),
+        tempdir_path: Some(temp_dir.path().to_path_buf()),
+        option_fields: options,
+    };
+
+    let spades_args = generate_cli(SPADES_TAG, &config, Some(&spades_config))?;
+
+    info!("[spades] command args: {:?}", spades_args);
+
+    let (mut spades_child, spades_stderr_task) = spawn_cmd(
+        config.clone(),
+        SPADES_TAG,
+        spades_args,
+        config.args.verbose,
+        None
     )
         .await?;
 
     info!(
-        "[assembly] chosen temp dir for contig filtering/indexing: {}",
-        temp_dir.path().display()
+        "[spades] child spawned: stdout_present={}, stderr_present={}",
+        spades_child.stdout.is_some(),
+        spades_child.stderr.is_some()
     );
 
-    let ram_fasta_path = NamedTempFile::with_suffix_in(".fa", &temp_dir)
-        .map_err(|e| PipelineError::Other(e.into()))?;
-    let ram_path = ram_fasta_path.path().to_owned();
-
-    // Contig length filtering
-    let rx = read_fasta(
-        raw_contigs_path.clone(),
-        u64::MAX,
-        Some(config.args.min_contig_length),
-        None,
-        &config
+    let spades_out_stream = parse_child_output(
+        &mut spades_child,
+        ChildStream::Stdout,
+        ParseMode::Lines,
+        &config,
     )
-        .map_err(|e| PipelineError::InvalidFastaFormat(e.to_string()))?;
-
-    let write_handle = write_fasta_stream_to_file(
-        ReceiverStream::new(rx),
-        ram_path.clone(),
-        config.clone(),
-        StreamDataType::JustBytes,
-        "process_assembly_contigs_filtering",
-    );
-
-    write_handle
         .await
-        .map_err(|e| PipelineError::Other(anyhow!("Writer task panicked: {}", e)))?
-        .map_err(|e| PipelineError::Other(anyhow!("Writer task failed: {}", e)))?;
+        .map_err(|e| PipelineError::ToolExecution {
+            tool: SPADES_TAG.to_string(),
+            error: e.to_string(),
+        })?;
 
-    fs::copy(&ram_path, &contigs_out).await
-        .map_err(|e| PipelineError::Other(anyhow!("Failed to copy contigs to output: {}", e)))?;
+    let spades_write_task = tokio::spawn(stream_to_file(
+        spades_out_stream,
+        stdout_log_path.clone(),
+    ));
+    cleanup_tasks.push(spades_write_task);
+
+    // stderr is drained and logged by spawn_cmd's internal stderr task
+    spades_stderr_task.await??;
+
+    // Check SPAdes exit
+    let spades_exit = spades_child.wait().await?;
 
     info!(
-        "[assembly] filtered contigs written: ram_path={} -> contigs_out={}",
-        ram_path.display(),
-        contigs_out.display()
+        "[spades] exit status={:?} success={}  stdout_log={}",
+        spades_exit.code(),
+        spades_exit.success(),
+        stdout_log_path.display()
     );
 
-    temp_files.push(ram_fasta_path);
-
-    let scaffolds_out = out_dir.join("scaffolds.fasta");
-    if raw_scaffolds_path.exists() {
-        fs::copy(&raw_scaffolds_path, &scaffolds_out).await?;
-        info!(
-            "[assembly] copied scaffolds: {} -> {}",
-            raw_scaffolds_path.display(),
-            scaffolds_out.display()
-        );
-    } else {
-        fs::write(&scaffolds_out, ";NO SCAFFOLDS").await?;
-        warn!(
-            "[assembly] raw scaffolds missing; wrote placeholder scaffolds at {}",
-            scaffolds_out.display()
-        );
+    match fs::metadata(&stdout_log_path).await {
+        Ok(meta) => info!(
+            "[spades] stdout log written: {} bytes at {}",
+            meta.len(),
+            stdout_log_path.display()
+        ),
+        Err(e) => warn!(
+            "[spades] stdout log missing or unreadable at {}: {}",
+            stdout_log_path.display(),
+            e
+        ),
     }
 
-    let index_dir = out_dir.join("bowtie_index");
+    let contigs_path = temp_dir.path().to_path_buf().join("contigs.fasta");
+    let contigs_all_path = temp_dir.path().to_path_buf().join("contigs_all.fasta");
+    let scaffolds_path = temp_dir.path().to_path_buf().join("scaffolds.fasta");
+    let bam_path = temp_dir.path().to_path_buf().join("read-contig.bam");
+    let stats_json_path = temp_dir.path().to_path_buf().join("contig_stats.json");
+
+
+    let final_contigs_path = assembly_out_dir.join("contigs.fasta");
+    let final_contigs_all_path = assembly_out_dir.join("contigs_all.fasta");
+    let final_scaffolds_path = assembly_out_dir.join("scaffolds.fasta");
+    let final_bam_path = assembly_out_dir.join("read-contig.bam");
+    let final_stats_json_path = assembly_out_dir.join("contig_stats.json");
+
+
+    if spades_exit.success() {
+        // on success path, just start the copy of the real spades output files async
+        info!("[spades] completed successfully");
+
+        // Copy the contigs file to contigs_all to reserve the original
+        fs::copy(&contigs_path, &contigs_all_path).await?;
+
+
+        // Contig length filtering and copy the result back over contigs.fasta
+        let rx = read_fasta(
+            contigs_all_path.clone(),
+            u64::MAX,
+            Some(config.args.min_contig_length),
+            None,
+            &config
+        )
+            .map_err(|e| PipelineError::InvalidFastaFormat(e.to_string()))?;
+
+        let write_handle = write_fasta_stream_to_file(
+            ReceiverStream::new(rx),
+            contigs_path.clone(),
+            config.clone(),
+            StreamDataType::JustBytes,
+            "process_assembly_contigs_filtering",
+        );
+
+        write_handle
+            .await
+            .map_err(|e| PipelineError::Other(anyhow!("contigs -> contigs_all writer task panicked: {}", e)))?
+            .map_err(|e| PipelineError::Other(anyhow!("contigs -> contigs_all writer task failed: {}", e)))?;
+
+        tokio::fs::copy(&contigs_path, &final_contigs_path).await?;
+        tokio::fs::copy(&contigs_all_path, &final_contigs_all_path).await?;
+        tokio::fs::copy(&scaffolds_path, &final_scaffolds_path).await?;
+
+    }
+    else {
+        error!("SPAdes failed with exit: {:?}", spades_exit);
+
+        let failed_marker = b";ASSEMBLY FAILED\n";
+        let empty_scaffolds = b";NO SCAFFOLDS\n";
+        let empty_bam = b"@NO INFO\n";
+        let empty_json = b"{}";
+
+        // Here we sync write the final output files to disk (fast)
+        // and pass those back as the "temp" files for the pipeline to use
+
+        tokio::fs::write(&final_contigs_path, failed_marker).await?;
+        tokio::fs::write(&final_scaffolds_path, empty_scaffolds).await?;
+        tokio::fs::write(&final_contigs_all_path, failed_marker).await?;
+        tokio::fs::write(&final_bam_path, empty_bam).await?;
+        tokio::fs::write(&final_stats_json_path, empty_json).await?;
+
+        info!(
+            "[spades] wrote dummy outputs after failure: contigs={}, scaffolds={}",
+            final_contigs_path.display(),
+            final_scaffolds_path.display(),
+        );
+
+        return Ok((
+            CoverageOutputs {
+                contigs_fasta: final_contigs_path,
+                contigs_all_fasta: final_contigs_all_path,
+                scaffolds_fasta: final_scaffolds_path,
+                bam_path: final_bam_path,
+                contig_stats_json: final_stats_json_path,
+                contig_stats: Arc::new(HashMap::new()),
+                read2contig: Arc::new(HashMap::new()),
+            },
+            ReceiverStream::new({
+                let (tx, rx) = mpsc::channel(1);
+                drop(tx);
+                rx
+            }),
+            cleanup_tasks,
+            cleanup_receivers,
+            temp_files,
+            temp_dir,
+        ));
+
+    }
+
+    info!("SPAdes completed successfully");
+
+
+    let index_dir = temp_dir.path().to_path_buf().join("bowtie_index");
     fs::create_dir_all(&index_dir).await?;
     let index_prefix = index_dir.join("contigs"); // will create contigs.1.bt2, etc.
 
@@ -4640,7 +4465,7 @@ pub async fn process_assembly(
             "--threads",
             &num_index_cores.to_string(),
             "--quiet",
-            ram_path.clone().to_str().unwrap(),
+            contigs_path.clone().to_str().unwrap(),
             index_prefix.to_str().unwrap(),
         ])
         .status()
@@ -4778,17 +4603,16 @@ pub async fn process_assembly(
         non_host_streams_iter.next().ok_or(PipelineError::EmptyStream)?
     );
 
-    let sam_path = out_dir.join("read-contig.bam");
 
-    let write_sam_task = write_byte_stream_to_file(
-        &sam_path,
+    let write_bam_task = write_byte_stream_to_file(
+        &bam_path,
         bam_for_file,
         config.clone(),
         StreamDataType::JustBytes,
         "process_assembly",
     )
         .await?;
-    cleanup_tasks.push(write_sam_task);
+    cleanup_tasks.push(write_bam_task);
 
     let bam_concurrency = compute_phase_concurrency(
         &config,
@@ -4814,16 +4638,22 @@ pub async fn process_assembly(
         read2contig.len()
     );
 
+    let stats_json = serde_json::to_string_pretty(&contig_stats)
+        .map_err(|e| PipelineError::Other(anyhow!("Failed to serialize contig_stats: {}", e)))?;
+
+    std::fs::write(&stats_json_path, &stats_json)
+        .map_err(|e| PipelineError::Other(anyhow!("Failed to write contig_stats.json: {}", e)))?;
+
+    tokio::fs::write(&final_stats_json_path, &stats_json).await
+        .map_err(|e| PipelineError::Other(anyhow!("Failed to write final contig_stats.json: {}", e)))?;
+
     Ok((
         CoverageOutputs {
-            contigs_fasta: out_dir.join("contigs.fasta"),
-            contigs_ram_fasta: ram_path.clone(),
-            contigs_all_fasta: out_dir.join("contigs_all.fasta"),
-            scaffolds_fasta: out_dir.join("scaffolds.fasta"),
-            sam_path: out_dir.join("read-contig.sam"),
-            contig_stats_json: out_dir.join("contig_stats.json"),
-            coverage_json: out_dir.join("assembly_contig_coverage.json"),
-            coverage_summary_csv: out_dir.join("assembly_contig_coverage_summary.csv"),
+            contigs_fasta: contigs_path,
+            contigs_all_fasta: contigs_all_path,
+            scaffolds_fasta: scaffolds_path,
+            bam_path: bam_path,
+            contig_stats_json: stats_json_path,
             contig_stats: Arc::new(contig_stats),
             read2contig: Arc::new(read2contig),
         },
@@ -4831,6 +4661,7 @@ pub async fn process_assembly(
         cleanup_tasks,
         cleanup_receivers,
         temp_files,
+        temp_dir
     ))
 }
 
@@ -6074,7 +5905,6 @@ pub async fn blast_contigs(
     Vec<oneshot::Receiver<Result<()>>>,
     Vec<NamedTempFile>,
 )> {
-    info!("blast_contigs start you piece of shit");
     use std::time::{Duration, Instant};
 
     let fn_start = Instant::now();
@@ -6219,7 +6049,6 @@ pub async fn blast_contigs(
         db_type, MAKEBLASTDB_TAG
     );
 
-    info!("blast_contigs right before making its stupid worthless db");
 
     let (_, makeblastdb_err_task) = spawn_cmd(
         config.clone(),
@@ -6272,7 +6101,7 @@ pub async fn blast_contigs(
         db_type,
         blast_command
     );
-    info!("blast_contigs right before spawing FUCK");
+    info!("blast_contigs right before spawning");
     let blast_spawn_start = Instant::now();
     let (mut blast_child, err_task) = spawn_cmd(
         config.clone(),
@@ -8490,18 +8319,15 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     // *******************
 
     // Assembly stats
-    let assembly_out_dir = out_dir.join("assembly");  // Assuming assembly_handle.out_dir was this
-    let assembly_work_dir = assembly_out_dir.join("spades");  // Match Python's subdir
-
+    let assembly_out_dir = out_dir.join("assembly");
 
 
     let (assembly_outputs, assembly_bam_out_stream,
         post_assembly_cleanup_tasks,
         post_assembly_cleanup_receivers,
-        post_assembly_temp_files) = process_assembly(
+        post_assembly_temp_files, post_assembly_temp_dir) = process_assembly(
         config.clone(),
         &assembly_out_dir,
-        &assembly_work_dir,
         non_host_r1_path.clone(),
         non_host_r2_path_opt.clone(),
         duplicate_clusters.clone(),
@@ -8512,15 +8338,17 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     cleanup_tasks.extend(post_assembly_cleanup_tasks);
     cleanup_receivers.extend(post_assembly_cleanup_receivers);
     temp_files.extend(post_assembly_temp_files);
+    final_temp_dirs.push(post_assembly_temp_dir);
 
-    let _ = fs::remove_dir_all(assembly_work_dir).await;
+    let coverage_json_path = assembly_out_dir.join("assembly_contig_coverage.json");
+    let coverage_summary_csv_path = assembly_out_dir.join("assembly_contig_coverage_summary.csv");
 
     let generate_assembly_coverage_result = generate_assembly_coverage(
         config.clone(),
         assembly_bam_out_stream,
         &assembly_outputs.contigs_fasta,
-        &assembly_outputs.coverage_json,
-        &assembly_outputs.coverage_summary_csv,
+        &coverage_json_path,
+        &coverage_summary_csv_path,
     )
         .await
         .map_err(|e| anyhow!("generate_assembly_coverage failed: {}", e))?;
@@ -8691,7 +8519,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     info!("NT blast_contigs concurrency: {}", nt_blast_concurrency);
 
     let nt_handle = tokio::spawn({
-        let contigs_fasta_path = assembly_outputs.contigs_ram_fasta.clone();
+        let contigs_fasta_path = assembly_outputs.contigs_fasta.clone();
         let config = config.clone();
         let lineage_map = lineage_map.clone();
         let should_keep_filter = should_keep_filter.clone();
@@ -8730,7 +8558,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     info!("NR blast_contigs concurrency: {}", nr_blast_concurrency);
 
     let nr_handle = tokio::spawn({
-        let contigs_fasta_path = assembly_outputs.contigs_ram_fasta.clone();
+        let contigs_fasta_path = assembly_outputs.contigs_fasta.clone();
         let config = config.clone();
         let lineage_map = lineage_map.clone();
         let should_keep_filter = should_keep_filter.clone();
@@ -8935,27 +8763,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     cleanup_tasks.extend(nr_cleanup_tasks);
     cleanup_receivers.extend(nr_cleanup_receivers);
     temp_files.extend(nr_temp_files);
-
-    let spades_task = spades_assembly(
-        config.clone(),
-        non_host_r1_path.clone(),
-        non_host_r2_path_opt.clone(),
-        &out_dir,
-    ).await?;
-
-    let spades_completion = spades_task.await;
-
-    match spades_completion {
-        Ok(Ok(())) => {
-            info!("SPAdes assembly task completed successfully");
-        }
-        Ok(Err(e)) => {
-            warn!("SPAdes assembly failed: {}", e);
-        }
-        Err(join_err) => {
-            error!("SPAdes task panicked or was cancelled: {}", join_err);
-        }
-    }
 
     // ────────────────────────────────────────────────────────────────
     // PRELOAD NR alignments (parallel version)
@@ -9262,10 +9069,10 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     let skip_coverage_viz = {
         let mut skip = false;
 
-        if !assembly_outputs.coverage_json.exists() {
+        if !coverage_json_path.exists() {
             warn!("Skipping coverage viz: contig_coverage_json missing (likely due to SPAdes assembly failure)");
             skip = true;
-        } else if assembly_outputs.coverage_json.metadata().map(|m| m.len() == 0).unwrap_or(true) {
+        } else if coverage_json_path.metadata().map(|m| m.len() == 0).unwrap_or(true) {
             warn!("Skipping coverage viz: contig_coverage_json is empty");
             skip = true;
         }
@@ -9288,7 +9095,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             generate_coverage_viz(
                 ReceiverStream::new(nt_hit_summary_coverage),
                 ReceiverStream::new(nt_refined_m8_top_stream_out),
-                assembly_outputs.coverage_json,
+                coverage_json_path,
                 assembly_outputs.contig_stats_json,
                 ReceiverStream::new(nt_m8_viz),
                 nt_info_db_path,

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -589,6 +589,7 @@ async fn bowtie2_filter_stream(
         subcommand: SamtoolsSubcommand::Fastq,
         subcommand_fields: HashMap::from([
             (fastq_flag.to_string(), None),
+            ("-N".to_string(), None),
             ("-".to_string(), None),
         ]),
     };
@@ -660,7 +661,7 @@ async fn bowtie2_filter_files(
     ).await?;
 
     let fastq_temp_dir = choose_temp_dir(
-        config.input_size, // FASTQ size ~ input size
+        config.input_size,
         &config.ram_temp_dir,
         &config.args.nvme_scratch,
         2,
@@ -674,41 +675,78 @@ async fn bowtie2_filter_files(
         None
     };
 
-    let mut fields = HashMap::new();
-    fields.insert("-f".to_string(), Some(if paired { "13".to_string() } else { "4".to_string() }));
-
     if paired {
+        let mut fields = HashMap::new();
+        fields.insert("-f".to_string(), Some("13".to_string()));
         fields.insert("-1".to_string(), Some(fq1.to_string_lossy().to_string()));
         fields.insert("-2".to_string(), Some(fq2.as_ref().unwrap().to_string_lossy().to_string()));
+        fields.insert("-N".to_string(), None);
         fields.insert("-0".to_string(), Some("/dev/null".to_string()));
         fields.insert("-s".to_string(), Some("/dev/null".to_string()));
+
+        let config_fastq = SamtoolsConfig {
+            subcommand: SamtoolsSubcommand::Fastq,
+            subcommand_fields: fields,
+        };
+
+        let args = generate_cli(SAMTOOLS_TAG, &config, Some(&config_fastq))?;
+
+        let (child, stdin_task, err_task) = stream_to_cmd(
+            config.clone(),
+            fastq_input_stream.into_inner(),
+            SAMTOOLS_TAG,
+            args,
+            StreamDataType::JustBytes,
+            config.args.verbose,
+            None
+        ).await?;
+
+        cleanup_tasks.push(stdin_task);
+        cleanup_tasks.push(err_task);
+
+        {
+            let mut guard = child.lock().await;
+            guard.wait().await?;
+        }
+
     } else {
-        fields.insert("-o".to_string(), Some(fq1.to_string_lossy().to_string()));
-    }
+        // streaming fastq (no -o flag)
+        let fastq_config = SamtoolsConfig {
+            subcommand: SamtoolsSubcommand::Fastq,
+            subcommand_fields: HashMap::from([
+                ("-f4".to_string(), None),
+                ("-".to_string(), None),
+                ("-N".to_string(), None),
+            ]),
+        };
 
-    let config_fastq = SamtoolsConfig {
-        subcommand: SamtoolsSubcommand::Fastq,
-        subcommand_fields: fields,
-    };
+        let fastq_args = generate_cli(SAMTOOLS_TAG, &config, Some(&fastq_config))?;
 
-    let args = generate_cli(SAMTOOLS_TAG, &config, Some(&config_fastq))?;
+        let (fastq_child, fastq_task, fastq_err_task) = stream_to_cmd(
+            config.clone(),
+            fastq_input_stream.into_inner(),
+            SAMTOOLS_TAG,
+            fastq_args,
+            StreamDataType::JustBytes,
+            config.args.verbose,
+            None
+        ).await?;
 
-    let (child, stdin_task, err_task) = stream_to_cmd(
-        config.clone(),
-        fastq_input_stream.into_inner(),
-        SAMTOOLS_TAG,
-        args,
-        StreamDataType::JustBytes,
-        config.args.verbose,
-        None
-    ).await?;
+        cleanup_tasks.extend([fastq_task, fastq_err_task]);
 
-    cleanup_tasks.push(stdin_task);
-    cleanup_tasks.push(err_task);
+        let fastq_stream = {
+            let mut guard = fastq_child.lock().await;
+            parse_child_output(&mut guard, ChildStream::Stdout, ParseMode::Fastq, &config).await?
+        };
 
-    {
-        let mut guard = child.lock().await;
-        guard.wait().await?;
+        let write_task = write_byte_stream_to_file(
+            &fq1,
+            ReceiverStream::new(fastq_stream),
+            config.clone(),
+            StreamDataType::JustBytes,
+            "bt2_fastq_se",
+        ).await?;
+        cleanup_tasks.push(write_task);
     }
 
     Ok((
@@ -722,6 +760,7 @@ async fn bowtie2_filter_files(
         vec![temp_dir, fastq_temp_dir]
     ))
 }
+
 
 /// HISAT2 filter
 ///

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -7699,25 +7699,14 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     ).await
         .map_err(|e| PipelineError::Other(e.into()))?;
 
+
     // Compute paths after temp_dir but before moving rx (only borrows with as_ref())
     let non_host_r1_path = non_host_temp_dir.path().join("nonhost_R1.fastq");
     let non_host_r2_path_opt = r2_rx_opt.as_ref().map(|_| non_host_temp_dir.path().join("nonhost_R2.fastq"));
 
-    // Now create monitored streams (this moves r1_rx and r2_rx_opt)
-    // let r1_monitored = monitor_stream(
-    //     ReceiverStream::new(r1_rx),
-    //     "Deinterleave_R1",
-    //     Duration::from_secs(5),
-    // );
-    // let r2_monitored_opt = r2_rx_opt.map(|rx| {
-    //     monitor_stream(
-    //         ReceiverStream::new(rx),
-    //         "Deinterleave_R2",
-    //         Duration::from_secs(5),
-    //     )
-    // });
 
     info!("Checkpoint: deinterleaving and writing non-host R1/R2 to temp (forces upstream completion). Writing to: {:?}", non_host_temp_dir);
+    final_temp_dirs.push(non_host_temp_dir);
 
     let r1_write_task_fut = write_parse_output_to_file(
         &non_host_r1_path,
@@ -8039,7 +8028,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
 
 
     // Diamond or MMseqs2 non_host alignment
-    let (non_host_m8_stream, mut non_host_cleanup_tasks, mut non_host_cleanup_receivers, non_host_temp_dirs) =
+    let (non_host_m8_stream, mut non_host_cleanup_tasks, mut non_host_cleanup_receivers, non_host_align_temp_dirs) =
         match config.alignment_backend {
             NRAlignmentBackend::Diamond => {
                 diamond_non_host_align(
@@ -8068,7 +8057,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
 
     cleanup_tasks.append(&mut non_host_cleanup_tasks);
     cleanup_receivers.append(&mut non_host_cleanup_receivers);
-    final_temp_dirs.extend(non_host_temp_dirs);
+    final_temp_dirs.extend(non_host_align_temp_dirs);
 
     let nr_concurrency = compute_phase_concurrency(
         &config,

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -6193,7 +6193,7 @@ pub async fn blast_contigs(
     );
 
 
-    let (_, makeblastdb_err_task) = spawn_cmd(
+    let (mut makeblastdb_child, makeblastdb_err_task) = spawn_cmd(
         config.clone(),
         MAKEBLASTDB_TAG,
         makeblastdb_args,
@@ -6201,7 +6201,23 @@ pub async fn blast_contigs(
         None
     )
         .await?;
-    cleanup_tasks.push(makeblastdb_err_task);
+
+    // Wait for makeblastdb to fully finish creating the index files
+    makeblastdb_child.wait().await.map_err(|e| PipelineError::ToolExecution {
+        tool: MAKEBLASTDB_TAG.to_string(),
+        error: format!("makeblastdb failed: {}", e),
+    })?;
+    makeblastdb_err_task.await??;
+
+    // Verify the index was actually created (BLAST looks for the .nal/.pal alias file)
+    let index_ext = if db_type == NT_TAG { "nal" } else { "pal" };
+    let expected_index = blastdb_path.with_extension(index_ext);
+    if !expected_index.exists() {
+        return Err(anyhow!(
+        "makeblastdb did not produce index file at {}",
+        expected_index.display()
+    ));
+    }
 
     let blast_command = if db_type == NT_TAG {
         BLASTN_TAG

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -2580,11 +2580,17 @@ pub async fn sort_m8_by_read_id(
         .map_err(|e| PipelineError::Other(anyhow!("{} writer task panicked: {}", tag, e)))?
         .map_err(|e| PipelineError::IOError(format!("{} writer task failed: {}", tag, e)))?;
 
+    let sort_buffer = if config.available_ram > 256 * 1024 * 1024 * 1024 {
+        "32G"
+    } else {
+        "8G"
+    };
+
     // 2) Only now spawn GNU sort, so it reads a complete file.
     let sort_config = crate::utils::command::sort::SortConfig {
         key: "-k1,1".to_string(),
         parallel: None,
-        buffer_size: Some("50%".to_string()),
+        buffer_size: Some(sort_buffer.to_string()),
         temp_dir: Some(temp_dir.path().to_string_lossy().into_owned()),
         output: Some(sorted_path.to_string_lossy().into_owned()),
         extra_fields: HashMap::new(),

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -800,6 +800,135 @@ async fn hisat2_filter(
     let mut cleanup_tasks = Vec::new();
     let cleanup_receivers = Vec::new();
 
+    // PAIRED-END PATH
+    if paired {
+        let temp_dir = choose_temp_dir(
+            config.input_size * headroom,
+            &config.ram_temp_dir,
+            &config.args.nvme_scratch,
+            4,
+            false
+        ).await?;
+
+        // 1. HISAT2 → SAM
+        let sam_path = temp_dir.path().join("hisat2.sam");
+        let hisat2_config = Hisat2Config {
+            hisat2_index_path: hisat2_index_path.clone(),
+            option_fields: hisat2_options,
+            r1_path: r1_path.to_string_lossy().to_string(),
+            r2_path: r2_path_opt.as_ref().map(|p| p.to_string_lossy().to_string()),
+        };
+
+        let mut hisat2_args = generate_cli(HISAT2_TAG, &config, Some(&hisat2_config))
+            .map_err(|e| PipelineError::ToolExecution { tool: HISAT2_TAG.to_string(), error: e.to_string() })?;
+
+        hisat2_args.push("-S".to_string());
+        hisat2_args.push(sam_path.to_string_lossy().to_string());
+
+        let (mut hisat2_child, hisat2_err_task) = spawn_cmd(
+            config.clone(), HISAT2_TAG, hisat2_args, config.args.verbose, None
+        ).await.map_err(|e| PipelineError::ToolExecution { tool: HISAT2_TAG.to_string(), error: e.to_string() })?;
+
+        cleanup_tasks.push(hisat2_err_task);
+
+        let status = hisat2_child.wait().await.map_err(|e| PipelineError::Other(e.into()))?;
+        if !status.success() {
+            return Err(PipelineError::ToolExecution { tool: HISAT2_TAG.to_string(), error: "HISAT2 execution failed".to_string() });
+        }
+
+        // 2. sort -n → BAM
+        let bam_path = temp_dir.path().join("hisat2_sorted.bam");
+        let sort_threads = config.thread_allocation(SAMTOOLS_TAG, Some("sort"));
+
+        let sort_config = SamtoolsConfig {
+            subcommand: SamtoolsSubcommand::Sort,
+            subcommand_fields: HashMap::from([
+                ("-n".to_string(), None),
+                ("-o".to_string(), Some(bam_path.to_string_lossy().to_string())),
+                ("-@".to_string(), Some(sort_threads.to_string())),
+                ("-T".to_string(), Some(temp_dir.path().to_string_lossy().to_string())),
+            ]),
+        };
+
+        let mut sort_args = generate_cli(SAMTOOLS_TAG, &config, Some(&sort_config))
+            .map_err(|e| PipelineError::ToolExecution { tool: SAMTOOLS_TAG.to_string(), error: e.to_string() })?;
+        sort_args.push(sam_path.to_string_lossy().to_string());
+
+        let (mut sort_child, sort_err_task) = spawn_cmd(
+            config.clone(), SAMTOOLS_TAG, sort_args, config.args.verbose, None
+        ).await.map_err(|e| PipelineError::ToolExecution { tool: SAMTOOLS_TAG.to_string(), error: e.to_string() })?;
+
+        cleanup_tasks.push(sort_err_task);
+        sort_child.wait().await.map_err(|e| PipelineError::Other(e.into()))?;
+
+        if let Some(out) = output_bam_path {
+            tokio::fs::copy(&bam_path, &out).await.map_err(|e| PipelineError::IOError(e.to_string()))?;
+        }
+
+        // 3. samtools fastq → R1/R2 files
+        let fq1_path = temp_dir.path().join("hisat2_filtered_R1.fastq");
+        let fq2_path = temp_dir.path().join("hisat2_filtered_R2.fastq");
+
+        let mut fastq_fields = HashMap::new();
+        fastq_fields.insert("-f".to_string(), Some("13".to_string()));
+        fastq_fields.insert("-1".to_string(), Some(fq1_path.to_string_lossy().to_string()));
+        fastq_fields.insert("-2".to_string(), Some(fq2_path.to_string_lossy().to_string()));
+        fastq_fields.insert("-0".to_string(), Some("/dev/null".to_string()));
+        fastq_fields.insert("-s".to_string(), Some("/dev/null".to_string()));
+
+        let fastq_config = SamtoolsConfig {
+            subcommand: SamtoolsSubcommand::Fastq,
+            subcommand_fields: fastq_fields,
+        };
+
+        let mut fastq_args = generate_cli(SAMTOOLS_TAG, &config, Some(&fastq_config))
+            .map_err(|e| PipelineError::ToolExecution { tool: SAMTOOLS_TAG.to_string(), error: e.to_string() })?;
+        fastq_args.push(bam_path.to_string_lossy().to_string());
+
+        let (mut fastq_child, fastq_err_task) = spawn_cmd(
+            config.clone(), SAMTOOLS_TAG, fastq_args, config.args.verbose, None
+        ).await.map_err(|e| PipelineError::ToolExecution { tool: SAMTOOLS_TAG.to_string(), error: e.to_string() })?;
+
+        cleanup_tasks.push(fastq_err_task);
+        fastq_child.wait().await.map_err(|e| PipelineError::Other(e.into()))?;
+
+        // 4. convert to stream
+        let (rx, read_task) = read_fastq(
+            fq1_path.clone(),
+            Some(fq2_path.clone()),
+            PairingMode::Strict,
+            None,
+            u64::MAX,
+            None,
+            None,
+            "hisat2_filter",
+            &config,
+        ).map_err(|e| PipelineError::Other(e))?;
+
+        cleanup_tasks.push(tokio::spawn(async move { read_task.await??; Ok(()) }));
+
+        let out_stream = ReceiverStream::new(rx);
+
+        // 5. mapped count
+        let (count_tx, count_rx) = oneshot::channel();
+        let count_task = tokio::spawn({
+            let bam_path = bam_path.clone();
+            async move {
+                let output = Command::new("samtools")
+                    .args(["view", "-c", "-F13", bam_path.to_str().unwrap()])
+                    .output()
+                    .await?;
+                let count = String::from_utf8_lossy(&output.stdout).trim().parse::<u64>().unwrap_or(0);
+                let _ = count_tx.send(count);
+                Ok::<(), anyhow::Error>(())
+            }
+        });
+        cleanup_tasks.push(count_task);
+
+        return Ok((out_stream, count_rx, cleanup_tasks, cleanup_receivers, vec![temp_dir]));
+    }
+
+
     let temp_dir = choose_temp_dir(
         config.input_size * headroom,
         &config.ram_temp_dir,
@@ -808,198 +937,166 @@ async fn hisat2_filter(
         false
     ).await?;
 
-    // ─────────────────────────────
-    // 1. HISAT2 → SAM
-    // ─────────────────────────────
-
-    let sam_path = temp_dir.path().join("hisat2.sam");
-
+    // 1. HISAT2 → SAM (streaming)
     let hisat2_config = Hisat2Config {
         hisat2_index_path: hisat2_index_path.clone(),
         option_fields: hisat2_options,
         r1_path: r1_path.to_string_lossy().to_string(),
-        r2_path: r2_path_opt.as_ref().map(|p| p.to_string_lossy().to_string()),
+        r2_path: None,
     };
 
     let mut hisat2_args = generate_cli(HISAT2_TAG, &config, Some(&hisat2_config))
-        .map_err(|e| PipelineError::ToolExecution {
-            tool: HISAT2_TAG.to_string(),
-            error: e.to_string(),
-        })?;
+        .map_err(|e| PipelineError::ToolExecution { tool: HISAT2_TAG.to_string(), error: e.to_string() })?;
 
     hisat2_args.push("-S".to_string());
-    hisat2_args.push(sam_path.to_string_lossy().to_string());
+    hisat2_args.push("/dev/stdout".to_string());
 
     let (mut hisat2_child, hisat2_err_task) = spawn_cmd(
-        config.clone(),
-        HISAT2_TAG,
-        hisat2_args,
-        config.args.verbose,
-        None
-    ).await.map_err(|e| PipelineError::ToolExecution {
-        tool: HISAT2_TAG.to_string(),
-        error: e.to_string(),
-    })?;
+        config.clone(), HISAT2_TAG, hisat2_args, config.args.verbose, None
+    ).await.map_err(|e| PipelineError::ToolExecution { tool: HISAT2_TAG.to_string(), error: e.to_string() })?;
 
     cleanup_tasks.push(hisat2_err_task);
 
-    let status = hisat2_child.wait().await
-        .map_err(|e| PipelineError::Other(e.into()))?;
+    let hisat2_sam_stream = {
+        let mut guard = hisat2_child;
+        parse_child_output(&mut guard, ChildStream::Stdout, ParseMode::Bytes, &config).await?
+    };
 
-    if !status.success() {
-        return Err(PipelineError::ToolExecution {
-            tool: HISAT2_TAG.to_string(),
-            error: "HISAT2 execution failed".to_string(),
-        });
-    }
-
-    // ─────────────────────────────
-    // 2. sort -n → BAM
-    // ─────────────────────────────
-
-    let bam_path = temp_dir.path().join("hisat2_sorted.bam");
+    // 2. samtools sort -n
+    let sort_threads = config.thread_allocation(SAMTOOLS_TAG, Some("sort"));
 
     let sort_config = SamtoolsConfig {
         subcommand: SamtoolsSubcommand::Sort,
         subcommand_fields: HashMap::from([
             ("-n".to_string(), None),
-            ("-o".to_string(), Some(bam_path.to_string_lossy().to_string())),
-            ("-@".to_string(), Some("8".to_string())),
+            ("-u".to_string(), None),
+            ("-O".to_string(), Some("bam".to_string())),
             ("-T".to_string(), Some(temp_dir.path().to_string_lossy().to_string())),
+            ("-@".to_string(), Some(sort_threads.to_string())),
+            ("-".to_string(), None),
         ]),
     };
 
-    let mut sort_args = generate_cli(SAMTOOLS_TAG, &config, Some(&sort_config))
-        .map_err(|e| PipelineError::ToolExecution {
-            tool: SAMTOOLS_TAG.to_string(),
-            error: e.to_string(),
-        })?;
+    let sort_args = generate_cli(SAMTOOLS_TAG, &config, Some(&sort_config))?;
 
-    sort_args.push(sam_path.to_string_lossy().to_string());
-
-    let (mut sort_child, sort_err_task) = spawn_cmd(
+    let (sort_child, sort_task, sort_err_task) = stream_to_cmd(
         config.clone(),
+        hisat2_sam_stream,
         SAMTOOLS_TAG,
         sort_args,
+        StreamDataType::JustBytes,
         config.args.verbose,
         None
-    ).await.map_err(|e| PipelineError::ToolExecution {
-        tool: SAMTOOLS_TAG.to_string(),
-        error: e.to_string(),
-    })?;
+    ).await?;
 
-    cleanup_tasks.push(sort_err_task);
+    cleanup_tasks.extend([sort_task, sort_err_task]);
 
-    sort_child.wait().await
-        .map_err(|e| PipelineError::Other(e.into()))?;
-
-    if let Some(out) = output_bam_path {
-        tokio::fs::copy(&bam_path, &out).await
-            .map_err(|e| PipelineError::IOError(e.to_string()))?;
-    }
-
-    // ─────────────────────────────
-    // 3. samtools fastq → R1/R2 files
-    // ─────────────────────────────
-
-    let fq1_path = temp_dir.path().join("hisat2_filtered_R1.fastq");
-
-    let fq2_path_opt = if paired {
-        Some(temp_dir.path().join("hisat2_filtered_R2.fastq"))
-    } else {
-        None
+    let sorted_bam_stream = {
+        let mut guard = sort_child.lock().await;
+        parse_child_output(&mut guard, ChildStream::Stdout, ParseMode::Bytes, &config).await?
     };
 
-    let mut fastq_fields = HashMap::new();
-    fastq_fields.insert(
-        "-f".to_string(),
-        Some(if paired { "13".to_string() } else { "4".to_string() }),
-    );
+    // 3. Always fanout for count + fastq (reuse existing fanout + splits pattern).
+    //    Write tee only if output_bam_path requested. Keeps streaming when None.
+    let num_tees = if output_bam_path.is_some() { 3 } else { 2 };
+    let (streams, router) = fanout_to_channels(
+        ReceiverStream::new(sorted_bam_stream),
+        num_tees,
+        "hisat2_bam_split",
+        &config,
+        StreamDataType::JustBytes,
+    ).await.map_err(|_| PipelineError::StreamDataDropped)?;
 
-    if paired {
-        fastq_fields.insert("-1".to_string(), Some(fq1_path.to_string_lossy().to_string()));
-        fastq_fields.insert("-2".to_string(), Some(fq2_path_opt.as_ref().unwrap().to_string_lossy().to_string()));
-        fastq_fields.insert("-0".to_string(), Some("/dev/null".to_string()));
-        fastq_fields.insert("-s".to_string(), Some("/dev/null".to_string()));
-    } else {
-        fastq_fields.insert("-o".to_string(), Some(fq1_path.to_string_lossy().to_string()));
+    let mut splits = streams.into_iter();
+    let count_stream = splits.next().ok_or(PipelineError::EmptyStream)?;
+    let fastq_stream = splits.next().ok_or(PipelineError::EmptyStream)?;
+
+    if let Some(bam_path) = output_bam_path {
+        let bam_write_stream = splits.next().ok_or(PipelineError::EmptyStream)?;
+        let write_task = write_byte_stream_to_file(
+            &bam_path,
+            ReceiverStream::new(bam_write_stream),
+            config.clone(),
+            StreamDataType::JustBytes,
+            "hisat2_bam_write"
+        ).await?;
+        cleanup_tasks.push(write_task);
     }
+    cleanup_tasks.push(router);
+
+    let fastq_input_stream = ReceiverStream::new(fastq_stream);
+
+    // 4. samtools fastq -f 4 → stdout (streaming)
+    let fastq_threads = config.thread_allocation(SAMTOOLS_TAG, Some("fastq"));
 
     let fastq_config = SamtoolsConfig {
         subcommand: SamtoolsSubcommand::Fastq,
-        subcommand_fields: fastq_fields,
+        subcommand_fields: HashMap::from([
+            ("-f4".to_string(), None),
+            ("-".to_string(), None),
+            ("-@".to_string(), Some(fastq_threads.to_string())),
+            ("-N".to_string(), None),
+        ]),
     };
 
-    let mut fastq_args = generate_cli(SAMTOOLS_TAG, &config, Some(&fastq_config))
-        .map_err(|e| PipelineError::ToolExecution {
-            tool: SAMTOOLS_TAG.to_string(),
-            error: e.to_string(),
-        })?;
+    let fastq_args = generate_cli(SAMTOOLS_TAG, &config, Some(&fastq_config))?;
 
-    fastq_args.push(bam_path.to_string_lossy().to_string());
-
-    let (mut fastq_child, fastq_err_task) = spawn_cmd(
+    let (fastq_child, fastq_task, fastq_err_task) = stream_to_cmd(
         config.clone(),
+        fastq_input_stream.into_inner(),
         SAMTOOLS_TAG,
         fastq_args,
+        StreamDataType::JustBytes,
         config.args.verbose,
         None
-    ).await.map_err(|e| PipelineError::ToolExecution {
-        tool: SAMTOOLS_TAG.to_string(),
-        error: e.to_string(),
-    })?;
+    ).await?;
 
-    cleanup_tasks.push(fastq_err_task);
+    cleanup_tasks.extend([fastq_task, fastq_err_task]);
 
-    fastq_child.wait().await
-        .map_err(|e| PipelineError::Other(e.into()))?;
+    let unmapped_fastq_stream = {
+        let mut guard = fastq_child.lock().await;
+        parse_child_output(&mut guard, ChildStream::Stdout, ParseMode::Fastq, &config).await?
+    };
 
-    // ─────────────────────────────
-    // 4. convert output FASTQ → stream (for downstream)
-    // ─────────────────────────────
+    let out_stream = ReceiverStream::new(unmapped_fastq_stream);
 
-    let (rx, read_task) = read_fastq(
-        fq1_path.clone(),
-        fq2_path_opt.clone(),
-        PairingMode::Strict,
-        None,
-        u64::MAX,
-        None,
-        None,
-        "hisat2_filter",
-        &config,
-    ).map_err(|e| PipelineError::Other(e))?;
-
-    cleanup_tasks.push(tokio::spawn(async move {
-        read_task.await??;
-        Ok(())
-    }));
-
-    let out_stream = ReceiverStream::new(rx);
-
-    // ─────────────────────────────
-    // 5. mapped count
-    // ─────────────────────────────
-
+    // 5. mapped count via streaming view -c -F4 on its tee (correct SE count, no data drop)
     let (count_tx, count_rx) = oneshot::channel();
+    let samtools_count_config = SamtoolsConfig {
+        subcommand: SamtoolsSubcommand::View,
+        subcommand_fields: HashMap::from([
+            ("-c".to_string(), None),
+            ("-F4".to_string(), None),
+            ("-".to_string(), None),
+        ]),
+    };
+    let count_args = generate_cli(SAMTOOLS_TAG, &config, Some(&samtools_count_config))?;
 
-    let count_task = tokio::spawn(async move {
-        let flag = if paired { "-F13" } else { "-F4" };
-        let output = Command::new("samtools")
-            .args(["view", "-c", flag, bam_path.to_str().unwrap()])
-            .output()
-            .await?;
+    let (count_child_arc, count_stream_task, count_err_task) = stream_to_cmd(
+        config.clone(),
+        count_stream,
+        SAMTOOLS_TAG,
+        count_args,
+        StreamDataType::JustBytes,
+        config.args.verbose,
+        None
+    ).await?;
 
-        let count = String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .parse::<u64>()
-            .unwrap_or(0);
+    cleanup_tasks.push(count_stream_task);
+    cleanup_tasks.push(count_err_task);
 
-        let _ = count_tx.send(count);
-        Ok::<(), anyhow::Error>(())
+    let count_future = tokio::spawn({
+        let config = config.clone();
+        async move {
+            let mut guard = count_child_arc.lock().await;
+            let lines = read_child_output_to_vec(&mut guard, ChildStream::Stdout, &config).await?;
+            let count_str = lines.first().map(|s| s.trim()).unwrap_or("0");
+            let count: u64 = count_str.parse().unwrap_or(0);
+            let _ = count_tx.send(count);
+            Ok::<(), anyhow::Error>(())
+        }
     });
-
-    cleanup_tasks.push(count_task);
+    cleanup_tasks.push(count_future);
 
     Ok((
         out_stream,
@@ -1009,6 +1106,7 @@ async fn hisat2_filter(
         vec![temp_dir]
     ))
 }
+
 
 /// QC's input stream using FASTP
 ///

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -4134,14 +4134,14 @@ pub fn parse_fasta_batch_to_annotated(
                 .map(|r| r.size)
                 .unwrap_or(1u64);
 
-            let seq_arc = record.seq_arc();
+
 
             if !is_unidentified {
                 let id = format!("NR:{}:NT:{}:{}", nr_acc, nt_acc, rep_id);
                 let mapped_rec = SequenceRecord::Fasta {
                     id,
                     desc: None,
-                    seq: seq_arc,
+                    seq: record.seq(),
                 };
                 if let Ok(bytes) = mapped_rec.to_bytes() {
                     let mut tagged = vec![0u8];
@@ -4152,7 +4152,7 @@ pub fn parse_fasta_batch_to_annotated(
                 let fasta_rep = SequenceRecord::Fasta {
                     id: rep_id.clone(),
                     desc: None,
-                    seq: seq_arc.clone(),
+                    seq: record.seq(),
                 };
                 if let Ok(bytes) = fasta_rep.to_bytes() {
                     // Unidentified (expanded)
@@ -4225,14 +4225,13 @@ pub fn parse_fasta_batch_to_annotated_streaming(
             .map(|r| r.size)
             .unwrap_or(1u64);
 
-        let seq_arc = record.seq_arc();
-
+        
         if !is_unidentified {
             let id = format!("NR:{}:NT:{}:{}", nr_acc, nt_acc, rep_id);
             let mapped_rec = SequenceRecord::Fasta {
                 id,
                 desc: None,
-                seq: seq_arc,
+                seq: record.seq(),
             };
             if let Ok(bytes) = mapped_rec.to_bytes() {
                 let mut tagged = vec![0u8];
@@ -4243,7 +4242,7 @@ pub fn parse_fasta_batch_to_annotated_streaming(
             let fasta_rep = SequenceRecord::Fasta {
                 id: rep_id.clone(),
                 desc: None,
-                seq: seq_arc.clone(),
+                seq: record.seq(),
             };
             if let Ok(bytes) = fasta_rep.to_bytes() {
                 let mut tagged_unid = vec![1u8];

--- a/src/utils/blast.rs
+++ b/src/utils/blast.rs
@@ -1140,7 +1140,7 @@ mod tests {
         assert_m8_eq(&scalar, &dispatched, line);
     }
 
-    // ── NT test constants (14 columns) ─────────────────────────────────────
+    // ── NT test constants ──────────────────────────────────────────────────
     const NT_BASIC: &str =
         "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903";
 
@@ -1159,7 +1159,7 @@ mod tests {
     const NT_EXTRA_COLUMNS: &str =
         "read5\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\textra1\textra2";
 
-    // ── NR test constants (12 columns) ─────────────────────────────────────
+    // ── NR test constants ──────────────────────────────────────────────────
     const NR_BASIC: &str =
         "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000";
 
@@ -1249,8 +1249,8 @@ mod tests {
     #[test]
     fn test_nr_qlen_slen_zero() {
         let r = M8Record::parse_line_nr_scalar(NR_BASIC).unwrap();
-        assert_eq!(r.qlen, 0, "NR qlen must default to 0");
-        assert_eq!(r.slen, 0, "NR slen must default to 0");
+        assert_eq!(r.qlen, 0);
+        assert_eq!(r.slen, 0);
     }
 
     #[test]
@@ -1272,7 +1272,91 @@ mod tests {
         assert!(M8Record::parse_line_nr(short).is_err());
     }
 
-    // ── Existing helper + consensus / aggregation / summarize tests ───────
+    // ── Stronger edge-case tests for malformed / extra columns ────────────
+
+    #[test]
+    fn test_nt_malformed_and_extra_columns() {
+        let cases = vec![
+            // Too few columns
+            "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000",
+            // Extra columns
+            "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\textra1\textra2\textra3",
+            // Trailing tab (empty last field)
+            "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\t",
+            // Empty field in the middle
+            "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t\t150\t29903",
+        ];
+
+        for line in cases {
+            // Should either both succeed with same result or both fail
+            let scalar_res = M8Record::parse_line_nt_scalar(line);
+            let dispatched_res = M8Record::parse_line_nt(line);
+
+            match (scalar_res, dispatched_res) {
+                (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, line),
+                (Err(_), Err(_)) => {} // both failed → acceptable
+                _ => panic!("Scalar and dispatched disagreed on error/success for: {}", line),
+            }
+        }
+    }
+
+    #[test]
+    fn test_nr_malformed_and_extra_columns() {
+        let cases = vec![
+            "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38",
+            "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000\textra1\textra2",
+            "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000\t",
+            "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t\t96\t1.45e-38\t152.000",
+        ];
+
+        for line in cases {
+            let scalar_res = M8Record::parse_line_nr_scalar(line);
+            let dispatched_res = M8Record::parse_line_nr(line);
+
+            match (scalar_res, dispatched_res) {
+                (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, line),
+                (Err(_), Err(_)) => {}
+                _ => panic!("Scalar and dispatched disagreed on: {}", line),
+            }
+        }
+    }
+
+    // ── Very long lines with many tags (stresses AVX-512 tab collection) ──
+
+    #[test]
+    fn test_nt_long_line_many_tags() {
+        let mut line = NT_BASIC.to_string();
+        for i in 0..60 {
+            line.push_str(&format!("\ttag{}:Z:value{}", i, i));
+        }
+        compare_nt(&line);
+    }
+
+    #[test]
+    fn test_nr_long_line_many_tags() {
+        let mut line = NR_BASIC.to_string();
+        for i in 0..60 {
+            line.push_str(&format!("\ttag{}:Z:value{}", i, i));
+        }
+        compare_nr(&line);
+    }
+
+    #[test]
+    fn test_nt_very_long_line_with_mixed_tags() {
+        let mut line = "long_read\tNC_045512.2\t99.9\t500\t5\t1\t1\t500\t10\t500\t1e-100\t800.0\t500\t29903".to_string();
+        for i in 0..80 {
+            if i % 3 == 0 {
+                line.push_str(&format!("\tAS:i:{}", 100 + i));
+            } else if i % 3 == 1 {
+                line.push_str(&format!("\tNM:i:{}", i));
+            } else {
+                line.push_str(&format!("\tcg:Z:{}M", i));
+            }
+        }
+        compare_nt(&line);
+    }
+
+    // ── Existing consensus / aggregation / summarize tests (unchanged) ────
 
     use fst::MapBuilder;
 

--- a/src/utils/blast.rs
+++ b/src/utils/blast.rs
@@ -221,14 +221,20 @@ impl M8Record {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx512f,avx512bw")]
     unsafe fn parse_line_nt_avx512_inner(line: &str) -> Result<Self> {
-        let bytes = line.trim_end().as_bytes();
-        if bytes.is_empty() { return Err(anyhow!("empty line")); }
+        let trimmed = line.trim_end();
+        let bytes = trimmed.as_bytes();
+        if bytes.is_empty() {
+            return Err(anyhow!("empty line"));
+        }
 
         let tab_pos = Self::collect_tab_positions(bytes);
         let len = bytes.len();
 
         if tab_pos.len() < 13 {
-            return Err(anyhow!("NT m8 line has {} tabs, need ≥13 for 14 fields", tab_pos.len()));
+            return Err(anyhow!(
+            "NT m8 line has {} tabs, need ≥13 for 14 fields",
+            tab_pos.len()
+        ));
         }
 
         macro_rules! field {
@@ -269,7 +275,7 @@ impl M8Record {
         let slen     = parse_u64!(13, "slen");
 
         if tab_pos.len() > 13 {
-            warn!("Extra columns in NT m8 line (expected 14)");
+            warn!("Extra columns in NT m8 line (expected 14): {}", trimmed);
         }
         Ok(Self { qname, tname, pident, alen, mismatch, gapopen, qstart, qend, tstart, tend, evalue, bitscore, qlen, slen })
     }
@@ -285,14 +291,20 @@ impl M8Record {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx512f,avx512bw")]
     unsafe fn parse_line_nr_avx512_inner(line: &str) -> Result<Self> {
-        let bytes = line.trim_end().as_bytes();
-        if bytes.is_empty() { return Err(anyhow!("empty line")); }
+        let trimmed = line.trim_end();
+        let bytes = trimmed.as_bytes();
+        if bytes.is_empty() {
+            return Err(anyhow!("empty line"));
+        }
 
         let tab_pos = Self::collect_tab_positions(bytes);
         let len = bytes.len();
 
         if tab_pos.len() < 11 {
-            return Err(anyhow!("NR m8 line has {} tabs, need ≥11 for 12 fields", tab_pos.len()));
+            return Err(anyhow!(
+            "NR m8 line has {} tabs, need ≥11 for 12 fields",
+            tab_pos.len()
+        ));
         }
 
         macro_rules! field {
@@ -331,8 +343,9 @@ impl M8Record {
         let bitscore = parse_f64!(11, "bitscore");
 
         if tab_pos.len() > 11 {
-            warn!("Extra columns in NR m8 line (expected 12)");
+            warn!("Extra columns in NT m8 line (expected 12): {}", trimmed);
         }
+
         Ok(Self { qname, tname, pident, alen, mismatch, gapopen, qstart, qend, tstart, tend, evalue, bitscore, qlen: 0, slen: 0 })
     }
 
@@ -1043,6 +1056,59 @@ pub async fn generate_taxon_count_json_from_m8(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_parse_line_nt_equivalence(
+            qname in "[a-zA-Z0-9._-]{1,100}",
+            tname in "[a-zA-Z0-9._-]{1,50}",
+            pident in 0.0..100.0,
+            alen in 0u64..10000,
+            mismatch in 0u64..1000,
+            gapopen in 0u64..100,
+            qstart in 1u64..10000,
+            qend in 1u64..10000,
+            tstart in 1u64..1000000,
+            tend in 1u64..1000000,
+            evalue in 0.0..1.0,
+            bitscore in 0.0..1000.0,
+            qlen in 1u64..10000,
+            slen in 1u64..1000000
+        ) {
+            let line = format!(
+                "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}\t{}\t{}",
+                qname, tname, pident, alen, mismatch, gapopen, qstart, qend,
+                tstart, tend, evalue, bitscore, qlen, slen
+            );
+            compare_nt(&line);
+        }
+
+        #[test]
+        fn test_parse_line_nr_equivalence(
+            qname in "[a-zA-Z0-9._-]{1,100}",
+            tname in "[a-zA-Z0-9._-]{1,50}",
+            pident in 0.0..100.0,
+            alen in 0u64..10000,
+            mismatch in 0u64..1000,
+            gapopen in 0u64..100,
+            qstart in 1u64..10000,
+            qend in 1u64..10000,
+            tstart in 1u64..1000000,
+            tend in 1u64..1000000,
+            evalue in 0.0..1.0,
+            bitscore in 0.0..1000.0
+        ) {
+            let line = format!(
+                "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}",
+                qname, tname, pident, alen, mismatch, gapopen, qstart, qend,
+                tstart, tend, evalue, bitscore
+            );
+            compare_nr(&line);
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
 
     #[allow(dead_code)]
     fn assert_m8_eq(a: &M8Record, b: &M8Record, ctx: &str) {
@@ -1074,7 +1140,7 @@ mod tests {
         assert_m8_eq(&scalar, &dispatched, line);
     }
 
-    // ── NT test lines (14 columns) ─────────────────────────────────────────
+    // ── NT test constants (14 columns) ─────────────────────────────────────
     const NT_BASIC: &str =
         "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903";
 
@@ -1090,7 +1156,10 @@ mod tests {
     const NT_TRAILING_WHITESPACE: &str =
         "read4\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903   ";
 
-    // ── NR test lines (12 columns) ─────────────────────────────────────────
+    const NT_EXTRA_COLUMNS: &str =
+        "read5\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\textra1\textra2";
+
+    // ── NR test constants (12 columns) ─────────────────────────────────────
     const NR_BASIC: &str =
         "read1\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000";
 
@@ -1099,6 +1168,12 @@ mod tests {
 
     const NR_GAPS: &str =
         "read3\tXYZ99999.2\t78.431\t153\t33\t3\t10\t162\t5\t155\t8.9e-20\t89.700";
+
+    const NR_TRAILING_WHITESPACE: &str =
+        "read4\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000   ";
+
+    const NR_EXTRA_COLUMNS: &str =
+        "read5\tQIK02963.1\t87.500\t96\t12\t0\t1\t96\t1\t96\t1.45e-38\t152.000\textra1\textra2";
 
     // ── NT tests ──────────────────────────────────────────────────────────
     #[test]
@@ -1122,29 +1197,29 @@ mod tests {
     }
 
     #[test]
+    fn test_nt_extra_columns() {
+        compare_nt(NT_EXTRA_COLUMNS);
+        let r = M8Record::parse_line_nt(NT_EXTRA_COLUMNS).unwrap();
+        assert_eq!(r.tname, "NC_045512");
+    }
+
+    #[test]
     fn test_nt_accession_version_stripped() {
         let r = M8Record::parse_line_nt_scalar(NT_BASIC).unwrap();
         assert_eq!(r.tname, "NC_045512", "version suffix must be stripped");
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        {
-            let avx = M8Record::parse_line_nt_avx512(NT_BASIC).unwrap();
-            assert_eq!(avx.tname, "NC_045512");
-        }
     }
 
     #[test]
     fn test_nt_error_on_empty() {
         assert!(M8Record::parse_line_nt_scalar("").is_err());
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        assert!(M8Record::parse_line_nt_avx512("").is_err());
+        assert!(M8Record::parse_line_nt("").is_err());
     }
 
     #[test]
     fn test_nt_error_on_too_few_fields() {
         let short = "read1\tNC_045512.2\t99.333\t150";
         assert!(M8Record::parse_line_nt_scalar(short).is_err());
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        assert!(M8Record::parse_line_nt_avx512(short).is_err());
+        assert!(M8Record::parse_line_nt(short).is_err());
     }
 
     // ── NR tests ──────────────────────────────────────────────────────────
@@ -1158,43 +1233,46 @@ mod tests {
     fn test_nr_gaps() { compare_nr(NR_GAPS); }
 
     #[test]
+    fn test_nr_trailing_whitespace() {
+        compare_nr(NR_TRAILING_WHITESPACE);
+        let r = M8Record::parse_line_nr_scalar(NR_TRAILING_WHITESPACE).unwrap();
+        assert_eq!(r.qname, "read4");
+    }
+
+    #[test]
+    fn test_nr_extra_columns() {
+        compare_nr(NR_EXTRA_COLUMNS);
+        let r = M8Record::parse_line_nr(NR_EXTRA_COLUMNS).unwrap();
+        assert_eq!(r.tname, "QIK02963");
+    }
+
+    #[test]
     fn test_nr_qlen_slen_zero() {
         let r = M8Record::parse_line_nr_scalar(NR_BASIC).unwrap();
         assert_eq!(r.qlen, 0, "NR qlen must default to 0");
         assert_eq!(r.slen, 0, "NR slen must default to 0");
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        {
-            let avx = M8Record::parse_line_nr_avx512(NR_BASIC).unwrap();
-            assert_eq!(avx.qlen, 0);
-            assert_eq!(avx.slen, 0);
-        }
     }
 
     #[test]
     fn test_nr_accession_version_stripped() {
         let r = M8Record::parse_line_nr_scalar(NR_BASIC).unwrap();
         assert_eq!(r.tname, "QIK02963");
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        {
-            let avx = M8Record::parse_line_nr_avx512(NR_BASIC).unwrap();
-            assert_eq!(avx.tname, "QIK02963");
-        }
     }
 
     #[test]
     fn test_nr_error_on_empty() {
         assert!(M8Record::parse_line_nr_scalar("").is_err());
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        assert!(M8Record::parse_line_nr_avx512("").is_err());
+        assert!(M8Record::parse_line_nr("").is_err());
     }
 
     #[test]
     fn test_nr_error_on_too_few_fields() {
         let short = "read1\tQIK02963.1\t87.500";
         assert!(M8Record::parse_line_nr_scalar(short).is_err());
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-        assert!(M8Record::parse_line_nr_avx512(short).is_err());
+        assert!(M8Record::parse_line_nr(short).is_err());
     }
+
+    // ── Existing helper + consensus / aggregation / summarize tests ───────
 
     use fst::MapBuilder;
 

--- a/src/utils/blast.rs
+++ b/src/utils/blast.rs
@@ -87,7 +87,7 @@ impl M8Record {
     // ── NT scalar ──────────────────────────────────────────────────────────
 
     /// Parse 14-column NT (blastn) output — scalar baseline.
-    fn parse_line_nt_scalar(line: &str) -> Result<Self> {
+    pub fn parse_line_nt_scalar(line: &str) -> Result<Self> {
         let line = line.trim_end();
         if line.is_empty() {
             return Err(anyhow!("empty line"));
@@ -139,7 +139,7 @@ impl M8Record {
     // ── NR scalar ──────────────────────────────────────────────────────────
 
     /// Parse 12-column NR (blastx) output — scalar baseline.
-    fn parse_line_nr_scalar(line: &str) -> Result<Self> {
+    pub fn parse_line_nr_scalar(line: &str) -> Result<Self> {
         let line = line.trim_end();
         if line.is_empty() {
             return Err(anyhow!("empty line"));

--- a/src/utils/blast.rs
+++ b/src/utils/blast.rs
@@ -1058,9 +1058,11 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    // ── Proptest with random extra tags ────────────────────────────────────
+
     proptest! {
         #[test]
-        fn test_parse_line_nt_equivalence(
+        fn test_parse_line_nt_equivalence_with_tags(
             qname in "[a-zA-Z0-9._-]{1,100}",
             tname in "[a-zA-Z0-9._-]{1,50}",
             pident in 0.0..100.0,
@@ -1074,18 +1076,27 @@ mod tests {
             evalue in 0.0..1.0,
             bitscore in 0.0..1000.0,
             qlen in 1u64..10000,
-            slen in 1u64..1000000
+            slen in 1u64..1000000,
+            extra_tags in prop::collection::vec(
+                ( "[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}" ),
+                0..40
+            )
         ) {
-            let line = format!(
+            let mut line = format!(
                 "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}\t{}\t{}",
                 qname, tname, pident, alen, mismatch, gapopen, qstart, qend,
                 tstart, tend, evalue, bitscore, qlen, slen
             );
+
+            for (key, typ, val) in extra_tags {
+                line.push_str(&format!("\t{}:{}{}", key, typ, val));
+            }
+
             compare_nt(&line);
         }
 
         #[test]
-        fn test_parse_line_nr_equivalence(
+        fn test_parse_line_nr_equivalence_with_tags(
             qname in "[a-zA-Z0-9._-]{1,100}",
             tname in "[a-zA-Z0-9._-]{1,50}",
             pident in 0.0..100.0,
@@ -1097,13 +1108,22 @@ mod tests {
             tstart in 1u64..1000000,
             tend in 1u64..1000000,
             evalue in 0.0..1.0,
-            bitscore in 0.0..1000.0
+            bitscore in 0.0..1000.0,
+            extra_tags in prop::collection::vec(
+                ( "[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}" ),
+                0..40
+            )
         ) {
-            let line = format!(
+            let mut line = format!(
                 "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}",
                 qname, tname, pident, alen, mismatch, gapopen, qstart, qend,
                 tstart, tend, evalue, bitscore
             );
+
+            for (key, typ, val) in extra_tags {
+                line.push_str(&format!("\t{}:{}{}", key, typ, val));
+            }
+
             compare_nr(&line);
         }
     }
@@ -1272,30 +1292,25 @@ mod tests {
         assert!(M8Record::parse_line_nr(short).is_err());
     }
 
-    // ── Stronger edge-case tests for malformed / extra columns ────────────
+    // ── Stronger edge-case tests ───────────────────────────────────────────
 
     #[test]
     fn test_nt_malformed_and_extra_columns() {
         let cases = vec![
-            // Too few columns
             "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000",
-            // Extra columns
             "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\textra1\textra2\textra3",
-            // Trailing tab (empty last field)
             "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t285.000\t150\t29903\t",
-            // Empty field in the middle
             "read1\tNC_045512.2\t99.333\t150\t1\t0\t1\t150\t100\t249\t1.23e-75\t\t150\t29903",
         ];
 
         for line in cases {
-            // Should either both succeed with same result or both fail
             let scalar_res = M8Record::parse_line_nt_scalar(line);
             let dispatched_res = M8Record::parse_line_nt(line);
 
             match (scalar_res, dispatched_res) {
                 (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, line),
-                (Err(_), Err(_)) => {} // both failed → acceptable
-                _ => panic!("Scalar and dispatched disagreed on error/success for: {}", line),
+                (Err(_), Err(_)) => {}
+                _ => panic!("Scalar vs dispatched disagreement on: {}", line),
             }
         }
     }
@@ -1316,12 +1331,10 @@ mod tests {
             match (scalar_res, dispatched_res) {
                 (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, line),
                 (Err(_), Err(_)) => {}
-                _ => panic!("Scalar and dispatched disagreed on: {}", line),
+                _ => panic!("Scalar vs dispatched disagreement on: {}", line),
             }
         }
     }
-
-    // ── Very long lines with many tags (stresses AVX-512 tab collection) ──
 
     #[test]
     fn test_nt_long_line_many_tags() {

--- a/src/utils/blast.rs
+++ b/src/utils/blast.rs
@@ -1058,11 +1058,38 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    // ── Proptest with random extra tags ────────────────────────────────────
+    // ── Strategy for generating tag fields (valid + malformed) ─────────────
+    fn tag_field_strategy() -> impl Strategy<Value = String> {
+        prop_oneof![
+            // Valid tag: key:type:value
+            ("[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}")
+                .prop_map(|(k, t, v)| format!("{}:{}{}", k, t, v)),
 
+            // Malformed: missing type (only one colon)
+            ("[A-Za-z0-9_]{1,10}", "[^:\\t\\n]{0,30}")
+                .prop_map(|(k, v)| format!("{}:{}", k, v)),
+
+            // Malformed: empty key
+            (":[A-Za-z]:[^\\t\\n]{0,30}").prop_map(|s| s.to_string()),
+
+            // Malformed: empty value
+            ("[A-Za-z0-9_]{1,10}:[A-Za-z]:").prop_map(|s| s.to_string()),
+
+            // Malformed: garbage / no colons
+            "[A-Za-z0-9_:\\-]{1,40}".prop_map(|s| s),
+
+            // Malformed: trailing colon only
+            "[A-Za-z0-9_]{1,10}:".prop_map(|s| s.to_string()),
+
+            // Empty tag field (consecutive tabs)
+            Just("".to_string()),
+        ]
+    }
+
+    // ── Proptests with random extra tags (valid + malformed) ───────────────
     proptest! {
         #[test]
-        fn test_parse_line_nt_equivalence_with_tags(
+        fn test_parse_line_nt_equivalence_with_malformed_tags(
             qname in "[a-zA-Z0-9._-]{1,100}",
             tname in "[a-zA-Z0-9._-]{1,50}",
             pident in 0.0..100.0,
@@ -1077,10 +1104,7 @@ mod tests {
             bitscore in 0.0..1000.0,
             qlen in 1u64..10000,
             slen in 1u64..1000000,
-            extra_tags in prop::collection::vec(
-                ( "[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}" ),
-                0..40
-            )
+            extra_tags in prop::collection::vec(tag_field_strategy(), 0..35)
         ) {
             let mut line = format!(
                 "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}\t{}\t{}",
@@ -1088,15 +1112,22 @@ mod tests {
                 tstart, tend, evalue, bitscore, qlen, slen
             );
 
-            for (key, typ, val) in extra_tags {
-                line.push_str(&format!("\t{}:{}{}", key, typ, val));
+            for tag in extra_tags {
+                line.push_str(&format!("\t{}", tag));
             }
 
-            compare_nt(&line);
+            let scalar_res = M8Record::parse_line_nt_scalar(&line);
+            let dispatched_res = M8Record::parse_line_nt(&line);
+
+            match (scalar_res, dispatched_res) {
+                (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, &line),
+                (Err(_), Err(_)) => {}
+                _ => panic!("Scalar and AVX-512 disagreed on success/failure for line: {}", line),
+            }
         }
 
         #[test]
-        fn test_parse_line_nr_equivalence_with_tags(
+        fn test_parse_line_nr_equivalence_with_malformed_tags(
             qname in "[a-zA-Z0-9._-]{1,100}",
             tname in "[a-zA-Z0-9._-]{1,50}",
             pident in 0.0..100.0,
@@ -1109,10 +1140,7 @@ mod tests {
             tend in 1u64..1000000,
             evalue in 0.0..1.0,
             bitscore in 0.0..1000.0,
-            extra_tags in prop::collection::vec(
-                ( "[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}" ),
-                0..40
-            )
+            extra_tags in prop::collection::vec(tag_field_strategy(), 0..35)
         ) {
             let mut line = format!(
                 "{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:e}\t{:.3}",
@@ -1120,11 +1148,18 @@ mod tests {
                 tstart, tend, evalue, bitscore
             );
 
-            for (key, typ, val) in extra_tags {
-                line.push_str(&format!("\t{}:{}{}", key, typ, val));
+            for tag in extra_tags {
+                line.push_str(&format!("\t{}", tag));
             }
 
-            compare_nr(&line);
+            let scalar_res = M8Record::parse_line_nr_scalar(&line);
+            let dispatched_res = M8Record::parse_line_nr(&line);
+
+            match (scalar_res, dispatched_res) {
+                (Ok(s), Ok(d)) => assert_m8_eq(&s, &d, &line),
+                (Err(_), Err(_)) => {}
+                _ => panic!("Scalar and AVX-512 disagreed on success/failure for line: {}", line),
+            }
         }
     }
 
@@ -1292,7 +1327,7 @@ mod tests {
         assert!(M8Record::parse_line_nr(short).is_err());
     }
 
-    // ── Stronger edge-case tests ───────────────────────────────────────────
+    // ── Additional strong edge-case tests ──────────────────────────────────
 
     #[test]
     fn test_nt_malformed_and_extra_columns() {
@@ -1354,22 +1389,7 @@ mod tests {
         compare_nr(&line);
     }
 
-    #[test]
-    fn test_nt_very_long_line_with_mixed_tags() {
-        let mut line = "long_read\tNC_045512.2\t99.9\t500\t5\t1\t1\t500\t10\t500\t1e-100\t800.0\t500\t29903".to_string();
-        for i in 0..80 {
-            if i % 3 == 0 {
-                line.push_str(&format!("\tAS:i:{}", 100 + i));
-            } else if i % 3 == 1 {
-                line.push_str(&format!("\tNM:i:{}", i));
-            } else {
-                line.push_str(&format!("\tcg:Z:{}M", i));
-            }
-        }
-        compare_nt(&line);
-    }
-
-    // ── Existing consensus / aggregation / summarize tests (unchanged) ────
+    // ── Existing consensus / aggregation / summarize tests ────────────────
 
     use fst::MapBuilder;
 

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -567,7 +567,6 @@ pub mod samtools {
                     args_vec.push(RunConfig::thread_allocation(run_config, SAMTOOLS_TAG, Some("fastq")).to_string());
                     args_vec.push("-c".to_string());
                     args_vec.push("6".to_string());
-                    args_vec.push("-n".to_string());
                 }
                 SamtoolsSubcommand::Stats => {
                     args_vec.push("stats".to_string());

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -1933,6 +1933,7 @@ pub mod spades {
         pub r1_path: PathBuf,                // Always required (R1 or single-end)
         pub r2_path_opt: Option<PathBuf>,    // Some(R2) for paired, None for single-end
         pub outdir_path: PathBuf,
+        pub tempdir_path: Option<PathBuf>,
         pub option_fields: HashMap<String, Option<String>>,  // e.g., {"--only-assembler": None}
     }
 
@@ -1984,6 +1985,11 @@ pub mod spades {
         );
             args_vec.push("-m".to_string());
             args_vec.push(spades_gb.to_string());
+
+            if let Some(tmp) = &config.tempdir_path {
+                args_vec.push("--tmp-dir".to_string());
+                args_vec.push(tmp.to_string_lossy().to_string());
+            }
 
             // Custom flags from config (e.g., --only-assembler)
             for (key, value) in config.option_fields.iter() {

--- a/src/utils/fastx.rs
+++ b/src/utils/fastx.rs
@@ -2400,13 +2400,69 @@ mod tests {
     fn test_parse_header_avx_vs_scalar_equivalence() {
         use proptest::prelude::*;
 
-        proptest!(|(s in "\\PC*")| {  // printable chars
-        let bytes = s.as_bytes();
-        let scalar = parse_header_scalar(bytes, '>');
-        let dispatched = parse_header(bytes, '>');
+        proptest!(|(s in "\\PC*", prefix in "[>@]")| {
+            let bytes = s.as_bytes();
+            let p = prefix.chars().next().unwrap();
+            let scalar = parse_header_scalar(bytes, p);
+            let dispatched = parse_header(bytes, p);
 
-        assert_eq!(scalar, dispatched, "Mismatch on: {:?}", s);
-    });
+            assert_eq!(scalar, dispatched, "Mismatch on: {:?} with prefix {}", s, p);
+        });
+    }
+
+    #[test]
+    fn test_parse_header_equivalence() {
+        // Long header that can span multiple 64-byte AVX-512 chunks
+        let long_header = b"very_long_id_that_spans_multiple_chunks_".repeat(4);
+
+        let cases: Vec<&[u8]> = vec![
+            b"seq1 first record",
+            b"seq1\tfirst record",
+            b"seq1\nfirst record",           // edge case with newline
+            b"seq1 first record with spaces",
+            b"seq1 ",                        // trailing space
+            b"seq1",                         // no description
+            b"very_long_id_that_spans_multiple_chunks_",
+            &long_header[..],                // long header for AVX-512 testing
+        ];
+
+        for &header in &cases {
+            let scalar = parse_header_scalar(header, '>');
+            let actual = parse_header(header, '>');
+
+            assert_eq!(
+                scalar, actual,
+                "Header mismatch on: {:?}\n  scalar: {:?}\n  actual: {:?}",
+                std::str::from_utf8(header),
+                scalar,
+                actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_header_long_and_edge_cases() {
+        let long_id = "a".repeat(250); // deliberately > 64*3 bytes
+
+        let test_cases: Vec<(&[u8], char)> = vec![
+            (long_id.as_bytes(), '>'),
+            (b"contig_00001 ", '>'),
+            (b"SRR12345.1 length=150", '@'),
+            (b"read1\tsome description with\ttabs", '@'),
+            (b"header_with_trailing_space ", '>'),
+        ];
+
+        for (header, prefix) in test_cases {
+            let scalar = parse_header_scalar(header, prefix);
+            let actual = parse_header(header, prefix);
+
+            assert_eq!(
+                scalar, actual,
+                "Failed on header: {:?} (prefix '{}')",
+                std::str::from_utf8(header),
+                prefix
+            );
+        }
     }
 
 

--- a/src/utils/fastx.rs
+++ b/src/utils/fastx.rs
@@ -72,13 +72,13 @@ pub enum SequenceRecord {
     Fasta {
         id: String,
         desc: Option<String>,
-        seq: Arc<Vec<u8>>,
+        seq: Bytes,
     },
     Fastq {
         id: String,
         desc: Option<String>,
-        seq: Arc<Vec<u8>>,
-        qual: Arc<Vec<u8>>,
+        seq: Bytes,
+        qual: Bytes,
     },
 }
 
@@ -90,35 +90,6 @@ impl SequenceRecord {
         }
     }
 
-    pub fn seq(&self) -> &[u8] {
-        match self {
-            SequenceRecord::Fasta { seq, .. } => &**seq,
-            SequenceRecord::Fastq { seq, .. } => &**seq,
-        }
-    }
-
-    pub fn seq_arc(&self) -> Arc<Vec<u8>> {
-        match self {
-            SequenceRecord::Fasta { seq, .. } => seq.clone(),
-            SequenceRecord::Fastq { seq, .. } => seq.clone(),
-        }
-    }
-
-    pub fn seq_owned(&self) -> Vec<u8> {
-        match self {
-            SequenceRecord::Fasta { seq, .. } => (**seq).clone(),
-            SequenceRecord::Fastq { seq, .. } => (**seq).clone(),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn qual(&self) -> &[u8] {
-        match self {
-            SequenceRecord::Fasta { .. } => &[],
-            SequenceRecord::Fastq { qual, .. } => &**qual,
-        }
-    }
-
     #[allow(dead_code)]
     pub fn desc(&self) -> Option<&str> {
         match self {
@@ -126,6 +97,27 @@ impl SequenceRecord {
             SequenceRecord::Fastq { desc, .. } => desc.as_deref(),
         }
     }
+
+
+    /// Cheap clone of the sequence bytes (refcount bump only).
+    pub fn seq(&self) -> Bytes {
+        match self {
+            SequenceRecord::Fasta { seq, .. } => seq.clone(),
+            SequenceRecord::Fastq { seq, .. } => seq.clone(),
+        }
+    }
+
+
+
+    #[allow(dead_code)]
+    pub fn qual(&self) -> Bytes {
+        match self {
+            SequenceRecord::Fasta { .. } => Bytes::new(),
+            SequenceRecord::Fastq { qual, .. } => qual.clone(),
+        }
+    }
+
+
 }
 
 
@@ -138,74 +130,72 @@ pub enum SequenceReader {
 impl From<needletail::parser::SequenceRecord<'_>> for SequenceRecord {
     fn from(record: needletail::parser::SequenceRecord<'_>) -> Self {
         let (id, desc) = parse_header(record.id(), if record.qual().is_some() { '@' } else { '>' });
+
         if let Some(qual) = record.qual() {
             SequenceRecord::Fastq {
                 id,
                 desc,
-                seq: Arc::new(record.seq().to_vec()),
-                qual: Arc::new(qual.to_vec()),
+                seq: Bytes::from(record.seq().to_vec()),
+                qual: Bytes::from(qual.to_vec()),
             }
         } else {
             SequenceRecord::Fasta {
                 id,
                 desc,
-                seq: Arc::new(record.seq().to_vec()),
+                seq: Bytes::from(record.seq().to_vec()),
             }
         }
     }
 }
 
 
-/// HashSet based sequence validator
-///
-///
-/// # Arguments
-///
-/// * `seq`: &[u8] ref to vec of bytes
-/// * 'valid_bases: vec of allowed bases
-///
-/// # Returns
-/// Result<(), String> for error if any
-#[allow(dead_code)]
-pub fn validate_sequence(seq: &Arc<Vec<u8>>, valid_bases: &[u8]) -> Result<()> {
-    let valid_bases_set: HashSet<u8> = valid_bases.iter().copied().collect();
-    if let Some(&invalid_base) = seq.iter().find(|&&b| !valid_bases_set.contains(&b)) {
-        Err(anyhow::anyhow!("Invalid nucleotide '{}' found in sequence", invalid_base as char))
-    } else {
-        Ok(())
+
+/// Validates that a sequence only contains allowed nucleotide bases.
+/// Accepts `&[u8]`, `Bytes`, `Vec<u8>`, `&Bytes`, etc.
+pub fn validate_sequence(seq: impl AsRef<[u8]>, valid_bases: &[u8]) -> Result<()> {
+    let seq = seq.as_ref();
+    let valid: HashSet<u8> = valid_bases.iter().copied().collect();
+
+    if let Some(&invalid) = seq.iter().find(|b| !valid.contains(b)) {
+        return Err(anyhow!(
+            "Invalid nucleotide '{}' found in sequence",
+            invalid as char
+        ));
     }
+    Ok(())
 }
 
+/// Parallel validation for very large sequences (e.g. long contigs).
+/// Uses cheap `Bytes` clones to distribute chunks across threads.
+pub async fn validate_sequence_parallel(
+    seq: Bytes,
+    valid_bases: &[u8],
+    num_threads: usize,
+) -> Result<()> {
+    if seq.is_empty() || num_threads == 0 {
+        return Ok(());
+    }
 
-/// PArallel HashSet based sequence validator
-/// for large sequences (probably over 1 billion bases)
-///
-/// # Arguments
-///
-/// * `seq`: &[u8] ref to vec of bytes
-/// * 'valid_bases: vec of allowed bases
-/// * num threads
-///
-/// # Returns
-/// Result<(), String> for error if any
-#[allow(dead_code)]
-pub async fn validate_sequence_parallel(seq: Arc<Vec<u8>>, valid_bases: &[u8], num_threads: usize) -> Result<()> {
-    let valid_bases_set: HashSet<u8> = valid_bases.iter().copied().collect();
-    let chunk_size = (seq.len() + num_threads - 1) / num_threads;
-    let mut handles: Vec<JoinHandle<Result<(), String>>> = Vec::new();
+    let valid: HashSet<u8> = valid_bases.iter().copied().collect();
+    let len = seq.len();
+    let chunk_size = (len + num_threads - 1) / num_threads;
+
+    let mut handles = Vec::with_capacity(num_threads);
 
     for i in 0..num_threads {
         let start = i * chunk_size;
-        let end = (start + chunk_size).min(seq.len());
-        if start >= seq.len() {
+        if start >= len {
             break;
         }
-        let seq_arc = Arc::clone(&seq);
-        let valid_bases_set = valid_bases_set.clone();
+        let end = (start + chunk_size).min(len);
+
+        // Cheap clone (refcount bump) + zero-copy slice
+        let chunk = seq.slice(start..end);
+        let valid = valid.clone();
+
         let handle = tokio::spawn(async move {
-            let chunk = &seq_arc[start..end];
-            if let Some(&invalid_base) = chunk.iter().find(|&&b| !valid_bases_set.contains(&b)) {
-                Err(format!("Invalid nucleotide '{}' found in sequence", invalid_base as char))
+            if let Some(&invalid) = chunk.iter().find(|b| !valid.contains(b)) {
+                Err(format!("Invalid nucleotide '{}' found in sequence", invalid as char))
             } else {
                 Ok(())
             }
@@ -213,10 +203,10 @@ pub async fn validate_sequence_parallel(seq: Arc<Vec<u8>>, valid_bases: &[u8], n
         handles.push(handle);
     }
 
-    let results = try_join_all(handles).await?;
-    for result in results {
-        result.map_err(|e| anyhow::anyhow!(e))?;
+    for handle in handles {
+        handle.await?.map_err(|e| anyhow!(e))?;
     }
+
     Ok(())
 }
 
@@ -1091,8 +1081,8 @@ pub fn fastx_generator(num_records: usize, seq_len: usize, mean: f32, stdev: f32
                 SequenceRecord::Fastq {
                     id: format!("read{}", i + 1),
                     desc: None,
-                    seq: Arc::new(seq.into_bytes()),
-                    qual: Arc::new(qual.into_bytes()),
+                    seq: Bytes::from(seq.into_bytes()),
+                    qual: Bytes::from(qual.into_bytes()),
                 }
             })
             .collect()
@@ -1136,7 +1126,7 @@ pub fn write_fasta_to_fifo(fasta_path: &PathBuf, fifo_path: &PathBuf) -> Result<
     while let Some(record_result) = reader.next() {
         let record = record_result.map_err(|e| anyhow!("Error reading FASTA: {}", e))?;
         let seq_record: SequenceRecord = record.to_owned().into();
-        let fasta_line = format!(">{}\n{}\n", seq_record.id(), String::from_utf8_lossy(seq_record.seq()));
+        let fasta_line = format!(">{}\n{}\n", seq_record.id(), String::from_utf8_lossy(&seq_record.seq()));
         fifo_file.write_all(fasta_line.as_bytes())?;
     }
     fifo_file.flush()?;
@@ -1366,8 +1356,8 @@ pub async fn concatenate_paired_reads(
                             let new_record = SequenceRecord::Fastq {
                                 id: r1_id.clone(),
                                 desc: r1_desc.clone(),
-                                seq: Arc::new(new_seq),
-                                qual: Arc::new(new_qual),
+                                seq: Bytes::from(new_seq),
+                                qual: Bytes::from(new_qual),
                             };
 
                             if tx.send(ParseOutput::Fastq(new_record)).await.is_err() {
@@ -1611,11 +1601,10 @@ pub async fn generate_taxid_fasta(
                             );
 
                             let (new_id, new_desc) = parse_header(new_header.trim_start_matches('>').as_bytes(), '>');
-                            let seq_arc = rec.seq_arc();
                             let new_rec = SequenceRecord::Fasta {
                                 id: new_id,
                                 desc: new_desc,
-                                seq: seq_arc,
+                                seq: rec.seq(),   // ← cheap Bytes clone (just refcount bump)
                             };
 
                             m_tx.send(ParseOutput::Fasta(new_rec.clone())).await.map_err(|_| anyhow!("mapped_tx dropped"))?;
@@ -1693,7 +1682,7 @@ pub async fn generate_taxid_fasta(
                             let new_rec = SequenceRecord::Fasta {
                                 id: new_id,
                                 desc: new_desc,
-                                seq: rec.seq_arc(),
+                                seq: rec.seq(),
                             };
 
 
@@ -2094,52 +2083,48 @@ mod tests {
         let fasta = SequenceRecord::Fasta {
             id: "contig1".to_string(),
             desc: Some("some desc".to_string()),
-            seq: Arc::new(b"ACGT".to_vec()),
+            seq: Bytes::from_static(b"ACGT"),
         };
 
         assert_eq!(fasta.id(), "contig1");
-        assert_eq!(fasta.seq(), b"ACGT");
-        assert_eq!(fasta.seq_owned(), b"ACGT".to_vec());
-        assert_eq!(fasta.qual(), b"");
+        assert_eq!(fasta.seq().as_ref(), b"ACGT");
+        assert_eq!(fasta.qual().as_ref(), b"");
         assert_eq!(fasta.desc(), Some("some desc"));
-        let fasta_arc = fasta.seq_arc();
-        assert!(Arc::ptr_eq(&fasta_arc, &fasta.seq_arc()));
+
+        // Cloning is cheap (refcount bump)
+        let fasta_clone = fasta.clone();
+        assert_eq!(fasta_clone.seq().as_ref(), b"ACGT");
 
         let fastq = SequenceRecord::Fastq {
             id: "read1".to_string(),
             desc: None,
-            seq: Arc::new(b"TGCA".to_vec()),
-            qual: Arc::new(b"IIII".to_vec()),
+            seq: Bytes::from_static(b"TGCA"),
+            qual: Bytes::from_static(b"IIII"),
         };
 
         assert_eq!(fastq.id(), "read1");
-        assert_eq!(fastq.seq(), b"TGCA");
-        assert_eq!(fastq.seq_owned(), b"TGCA".to_vec());
-        assert_eq!(fastq.qual(), b"IIII");
+        assert_eq!(fastq.seq().as_ref(), b"TGCA");
+        assert_eq!(fastq.qual().as_ref(), b"IIII");
         assert_eq!(fastq.desc(), None);
-        let fastq_arc = fastq.seq_arc();
-        assert!(Arc::ptr_eq(&fastq_arc, &fastq.seq_arc()));
+
+        // Cloning is cheap
+        let fastq_clone = fastq.clone();
+        assert_eq!(fastq_clone.seq().as_ref(), b"TGCA");
     }
 
     #[test]
     fn test_validate_sequence() {
-        let valid = Arc::new(b"ACGTACGT".to_vec());
-        assert!(validate_sequence(&valid, b"ACGT").is_ok());
+        assert!(validate_sequence(b"ACGTACGT", b"ACGT").is_ok());
 
-        let invalid = Arc::new(b"ACNT".to_vec());
-        let err = validate_sequence(&invalid, b"ACGT").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Invalid nucleotide"));
-        assert!(msg.contains("N"));
+        let err = validate_sequence(b"ACNT", b"ACGT").unwrap_err();
+        assert!(err.to_string().contains("Invalid nucleotide"));
     }
 
     #[tokio::test]
     async fn test_validate_sequence_parallel() -> Result<()> {
-        let valid = Arc::new(b"ACGTACGTACGT".to_vec());
-        validate_sequence_parallel(valid, b"ACGT", 3).await?;
+        validate_sequence_parallel(Bytes::from_static(b"ACGTACGTACGT"), b"ACGT", 3).await?;
 
-        let invalid = Arc::new(b"ACGTXCGT".to_vec());
-        let err = validate_sequence_parallel(invalid, b"ACGT", 3)
+        let err = validate_sequence_parallel(Bytes::from_static(b"ACGTXCGT"), b"ACGT", 3)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("Invalid nucleotide"));
@@ -2278,8 +2263,8 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
 
@@ -2302,7 +2287,7 @@ mod tests {
             ParseOutput::Fasta(SequenceRecord::Fasta {
                 id: "seq2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
             }),
         ];
 
@@ -2334,8 +2319,8 @@ mod tests {
             tx.send(ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "keep_me_01".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }))
                 .await
                 .unwrap();
@@ -2343,8 +2328,8 @@ mod tests {
             tx.send(ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "ignore_me_02".to_string(),
                 desc: None,
-                seq: Arc::new(b"TGCA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"TGCA"),
+                qual: Bytes::from_static(b"HHHH"),
             }))
                 .await
                 .unwrap();
@@ -2362,7 +2347,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id(), "keep_me_01");
-        assert_eq!(results[0].seq(), b"ATCG");
+        assert_eq!(results[0].seq().as_ref(), b"ATCG");   // ← fixed
         Ok(())
     }
 
@@ -2391,8 +2376,8 @@ mod tests {
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].id(), "read1");
-        assert_eq!(records[0].seq(), b"ACGT");
-        assert_eq!(records[0].qual(), b"IIII");
+        assert_eq!(records[0].seq().as_ref(), b"ACGT");     // ← fixed
+        assert_eq!(records[0].qual().as_ref(), b"IIII");    // ← fixed
         Ok(())
     }
 
@@ -2403,14 +2388,14 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
 
@@ -2432,8 +2417,8 @@ mod tests {
 
         assert_eq!(concat_records.len(), 1);
         assert_eq!(concat_records[0].id(), "read1/1");
-        assert_eq!(concat_records[0].seq(), b"ATCGNGCTA");
-        assert_eq!(concat_records[0].qual(), b"IIII!HHHH");
+        assert_eq!(concat_records[0].seq().as_ref(), b"ATCGNGCTA");   // ← fixed
+        assert_eq!(concat_records[0].qual().as_ref(), b"IIII!HHHH");  // ← fixed
         Ok(())
     }
 }

--- a/src/utils/fastx.rs
+++ b/src/utils/fastx.rs
@@ -363,31 +363,19 @@ pub fn r1r2_base(path: &PathBuf)  -> R1R2Result {
 /// # Arguments
 /// * `head`   - Header bytes (needletail has already stripped the leading `>`/`@`).
 /// * `prefix` - The leading character (`>` or `@`) to strip from the id field.
-///
+/// Note: needletail already stripped the leading > or @.
 /// # Returns
 /// `(id, desc)` — desc is `None` when the header has no whitespace.
 pub fn parse_header(head: &[u8], prefix: char) -> (String, Option<String>) {
     PARSE_HEADER_FN(head, prefix)
 }
 
-/// Scalar path — used on non-AVX-512 hardware.
+/// Scalar path — reference implementation.
 fn parse_header_scalar(head: &[u8], prefix: char) -> (String, Option<String>) {
-    match memchr3(b' ', b'\t', b'\n', head) {
-        Some(pos) => {
-            let id_bytes = &head[..pos];
-            let desc_bytes = &head[pos + 1..];
-            let id = String::from_utf8_lossy(id_bytes)
-                .trim_start_matches(prefix)
-                .to_string();
-            let desc = if desc_bytes.is_empty() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(desc_bytes).into_owned())
-            };
-            (id, desc)
-        }
+    match memchr::memchr3(b' ', b'\t', b'\n', head) {
+        Some(pos) => parse_from_pos(head, pos, prefix),
         None => {
-            // id-only header (e.g. ">NC_045512.2" with no description)
+            // id-only header
             let id = String::from_utf8_lossy(head)
                 .trim_start_matches(prefix)
                 .to_string();
@@ -396,14 +384,16 @@ fn parse_header_scalar(head: &[u8], prefix: char) -> (String, Option<String>) {
     }
 }
 
-/// AVX-512 path — 64-byte sweep to find the first whitespace byte.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f,avx512bw")]
 unsafe fn parse_header_avx512_inner(head: &[u8], prefix: char) -> (String, Option<String>) {
     use std::arch::x86_64::*;
-    use std::arch::x86_64::__m512i;
 
     let len = head.len();
+    if len == 0 {
+        return (String::new(), None);
+    }
+
     let space_splat = _mm512_set1_epi8(b' ' as i8);
     let tab_splat   = _mm512_set1_epi8(b'\t' as i8);
     let nl_splat    = _mm512_set1_epi8(b'\n' as i8);
@@ -413,59 +403,41 @@ unsafe fn parse_header_avx512_inner(head: &[u8], prefix: char) -> (String, Optio
         let chunk = _mm512_loadu_si512(head.as_ptr().add(i).cast::<__m512i>());
         let mask: u64 =
             _mm512_cmpeq_epi8_mask(chunk, space_splat) |
-            _mm512_cmpeq_epi8_mask(chunk, tab_splat)   |
-            _mm512_cmpeq_epi8_mask(chunk, nl_splat);
+                _mm512_cmpeq_epi8_mask(chunk, tab_splat)   |
+                _mm512_cmpeq_epi8_mask(chunk, nl_splat);
+
         if mask != 0 {
             let pos = i + mask.trailing_zeros() as usize;
-            let id_bytes   = &head[..pos];
-            let desc_bytes = &head[pos + 1..];
-            let id = String::from_utf8_lossy(id_bytes)
-                .trim_start_matches(prefix)
-                .to_string();
-            let desc = if desc_bytes.is_empty() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(desc_bytes).into_owned())
-            };
-            return (id, desc);
+            return parse_from_pos(head, pos, prefix);
         }
         i += 64;
     }
-    // Scalar tail for remaining < 64 bytes (also handles id-only headers)
-    parse_header_scalar(&head[i..], prefix).map_id_offset(i, head, prefix)
+
+    // Tail (< 64 bytes) → use scalar
+    parse_header_scalar(&head[i..], prefix)
 }
 
-// Helper to re-run scalar on tail bytes and merge the offset back.
-// Only called for headers whose whitespace (if any) falls in the tail.
-#[cfg(target_arch = "x86_64")]
-trait MergeOffset {
-    fn map_id_offset(self, offset: usize, full: &[u8], prefix: char) -> Self;
-}
-#[cfg(target_arch = "x86_64")]
-impl MergeOffset for (String, Option<String>) {
-    fn map_id_offset(self, offset: usize, full: &[u8], prefix: char) -> Self {
-        // If scalar found a split in the tail, the id must be re-extracted
-        // from the full slice (offset..split) to be complete.
-        let (tail_id, desc) = self;
-        if desc.is_some() {
-            // whitespace was in the tail — id spans from 0..offset + tail_id length
-            let full_id = String::from_utf8_lossy(&full[..offset + tail_id.len()])
-                .trim_start_matches(prefix)
-                .to_string();
-            (full_id, desc)
-        } else {
-            // no whitespace anywhere — id is the full header
-            let full_id = String::from_utf8_lossy(full)
-                .trim_start_matches(prefix)
-                .to_string();
-            (full_id, None)
-        }
-    }
+/// Core logic: given a known position of the first whitespace, extract id + desc.
+/// This is shared between scalar and AVX-512 paths.
+fn parse_from_pos(head: &[u8], pos: usize, prefix: char) -> (String, Option<String>) {
+    let id_bytes = &head[..pos];
+    let desc_bytes = &head[pos + 1..];
+
+    let id = String::from_utf8_lossy(id_bytes)
+        .trim_start_matches(prefix)
+        .to_string();
+
+    let desc = if desc_bytes.is_empty() {
+        None
+    } else {
+        Some(String::from_utf8_lossy(desc_bytes).into_owned())
+    };
+
+    (id, desc)
 }
 
 #[cfg(target_arch = "x86_64")]
 fn parse_header_avx512(head: &[u8], prefix: char) -> (String, Option<String>) {
-    // Safety: only reachable when SIMD_LEVEL == Avx512, confirmed at startup.
     unsafe { parse_header_avx512_inner(head, prefix) }
 }
 
@@ -478,6 +450,8 @@ static PARSE_HEADER_FN: Lazy<fn(&[u8], char) -> (String, Option<String>)> = Lazy
     debug!("parse_header: using scalar path");
     parse_header_scalar
 });
+
+
 
 
 /// Reads a FASTQ file.
@@ -2421,4 +2395,19 @@ mod tests {
         assert_eq!(concat_records[0].qual().as_ref(), b"IIII!HHHH");  // ← fixed
         Ok(())
     }
+
+    #[test]
+    fn test_parse_header_avx_vs_scalar_equivalence() {
+        use proptest::prelude::*;
+
+        proptest!(|(s in "\\PC*")| {  // printable chars
+        let bytes = s.as_bytes();
+        let scalar = parse_header_scalar(bytes, '>');
+        let dispatched = parse_header(bytes, '>');
+
+        assert_eq!(scalar, dispatched, "Mismatch on: {:?}", s);
+    });
+    }
+
+
 }

--- a/src/utils/fastx.rs
+++ b/src/utils/fastx.rs
@@ -413,8 +413,9 @@ unsafe fn parse_header_avx512_inner(head: &[u8], prefix: char) -> (String, Optio
         i += 64;
     }
 
-    // Tail (< 64 bytes) → use scalar
-    parse_header_scalar(&head[i..], prefix)
+    // Fallback: use scalar on the full header for correctness
+    // (handles long headers and headers with no whitespace)
+    parse_header_scalar(head, prefix)
 }
 
 /// Core logic: given a known position of the first whitespace, extract id + desc.

--- a/src/utils/fastx.rs
+++ b/src/utils/fastx.rs
@@ -2065,7 +2065,6 @@ mod tests {
         assert_eq!(fasta.qual().as_ref(), b"");
         assert_eq!(fasta.desc(), Some("some desc"));
 
-        // Cloning is cheap (refcount bump)
         let fasta_clone = fasta.clone();
         assert_eq!(fasta_clone.seq().as_ref(), b"ACGT");
 
@@ -2081,7 +2080,6 @@ mod tests {
         assert_eq!(fastq.qual().as_ref(), b"IIII");
         assert_eq!(fastq.desc(), None);
 
-        // Cloning is cheap
         let fastq_clone = fastq.clone();
         assert_eq!(fastq_clone.seq().as_ref(), b"TGCA");
     }
@@ -2227,8 +2225,6 @@ mod tests {
         Ok(())
     }
 
-  
-
     #[tokio::test]
     async fn test_stream_record_counter_fastq() -> Result<()> {
         let (tx, rx) = mpsc::channel(10);
@@ -2321,7 +2317,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id(), "keep_me_01");
-        assert_eq!(results[0].seq().as_ref(), b"ATCG");   // ← fixed
+        assert_eq!(results[0].seq().as_ref(), b"ATCG");
         Ok(())
     }
 
@@ -2350,8 +2346,8 @@ mod tests {
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].id(), "read1");
-        assert_eq!(records[0].seq().as_ref(), b"ACGT");     // ← fixed
-        assert_eq!(records[0].qual().as_ref(), b"IIII");    // ← fixed
+        assert_eq!(records[0].seq().as_ref(), b"ACGT");
+        assert_eq!(records[0].qual().as_ref(), b"IIII");
         Ok(())
     }
 
@@ -2391,8 +2387,8 @@ mod tests {
 
         assert_eq!(concat_records.len(), 1);
         assert_eq!(concat_records[0].id(), "read1/1");
-        assert_eq!(concat_records[0].seq().as_ref(), b"ATCGNGCTA");   // ← fixed
-        assert_eq!(concat_records[0].qual().as_ref(), b"IIII!HHHH");  // ← fixed
+        assert_eq!(concat_records[0].seq().as_ref(), b"ATCGNGCTA");
+        assert_eq!(concat_records[0].qual().as_ref(), b"IIII!HHHH");
         Ok(())
     }
 
@@ -2412,18 +2408,17 @@ mod tests {
 
     #[test]
     fn test_parse_header_equivalence() {
-        // Long header that can span multiple 64-byte AVX-512 chunks
         let long_header = b"very_long_id_that_spans_multiple_chunks_".repeat(4);
 
         let cases: Vec<&[u8]> = vec![
             b"seq1 first record",
             b"seq1\tfirst record",
-            b"seq1\nfirst record",           // edge case with newline
+            b"seq1\nfirst record",
             b"seq1 first record with spaces",
-            b"seq1 ",                        // trailing space
-            b"seq1",                         // no description
+            b"seq1 ",
+            b"seq1",
             b"very_long_id_that_spans_multiple_chunks_",
-            &long_header[..],                // long header for AVX-512 testing
+            &long_header[..],
         ];
 
         for &header in &cases {
@@ -2442,7 +2437,7 @@ mod tests {
 
     #[test]
     fn test_parse_header_long_and_edge_cases() {
-        let long_id = "a".repeat(250); // deliberately > 64*3 bytes
+        let long_id = "a".repeat(250);
 
         let test_cases: Vec<(&[u8], char)> = vec![
             (long_id.as_bytes(), '>'),
@@ -2464,6 +2459,4 @@ mod tests {
             );
         }
     }
-
-
 }

--- a/src/utils/paf.rs
+++ b/src/utils/paf.rs
@@ -380,6 +380,35 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    // ── Strategy for generating tag fields (valid + malformed) ─────────────
+    fn tag_field_strategy() -> impl Strategy<Value = String> {
+        prop_oneof![
+            // Valid tag: key:type:value
+            ("[A-Za-z0-9_]{1,10}", "[A-Za-z]:", "[^\\t\\n]{0,40}")
+                .prop_map(|(k, t, v)| format!("{}:{}{}", k, t, v)),
+
+            // Malformed: missing type (only one colon)
+            ("[A-Za-z0-9_]{1,10}", "[^:\\t\\n]{0,30}")
+                .prop_map(|(k, v)| format!("{}:{}", k, v)),
+
+            // Malformed: empty key
+            (":[A-Za-z]:[^\\t\\n]{0,30}").prop_map(|s| s.to_string()),
+
+            // Malformed: empty value
+            ("[A-Za-z0-9_]{1,10}:[A-Za-z]:").prop_map(|s| s.to_string()),
+
+            // Malformed: garbage / no colons
+            "[A-Za-z0-9_:\\-]{1,40}".prop_map(|s| s),
+
+            // Malformed: trailing colon only
+            "[A-Za-z0-9_]{1,10}:".prop_map(|s| s.to_string()),
+
+            // Empty tag field (consecutive tabs)
+            Just("".to_string()),
+        ]
+    }
+
+    // ── Basic field proptest ───────────────────────────────────────────────
     proptest! {
         #[test]
         fn test_parse_line_paf_equivalence(
@@ -401,6 +430,44 @@ mod tests {
                 qname, qlen, qstart, qend, strand, tname, tlen, tstart, tend, nmatch, alen, mapq
             );
             compare_parsers(&line);
+        }
+    }
+
+    // ── Proptests with random extra tags (valid + malformed) ───────────────
+    proptest! {
+        #[test]
+        fn test_parse_line_paf_equivalence_with_malformed_tags(
+            qname in "[a-zA-Z0-9._-]{1,100}",
+            qlen in 1u64..1000000,
+            qstart in 0u64..1000000,
+            qend in 0u64..1000000,
+            strand in "[+-]",
+            tname in "[a-zA-Z0-9._-]{1,100}",
+            tlen in 1u64..1000000000,
+            tstart in 0u64..1000000000,
+            tend in 0u64..1000000000,
+            nmatch in 0u64..1000000,
+            alen in 0u64..1000000,
+            mapq in 0u8..60,
+            extra_tags in prop::collection::vec(tag_field_strategy(), 0..40)
+        ) {
+            let mut line = format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                qname, qlen, qstart, qend, strand, tname, tlen, tstart, tend, nmatch, alen, mapq
+            );
+
+            for tag in extra_tags {
+                line.push_str(&format!("\t{}", tag));
+            }
+
+            let scalar_res = PafRecord::parse_line_scalar(&line);
+            let dispatched_res = PafRecord::parse_line(&line);
+
+            match (scalar_res, dispatched_res) {
+                (Ok(s), Ok(d)) => assert_records_eq(&s, &d, &line),
+                (Err(_), Err(_)) => {}
+                _ => panic!("Scalar and AVX-512 disagreed on success/failure for line: {}", line),
+            }
         }
     }
 
@@ -543,18 +610,18 @@ mod tests {
     fn test_parse_paf_batch_to_m8_roundtrip() {
         let batch = format!("{}\n{}\n{}\n", BASIC, WITH_TAGS, REVERSE_STRAND);
         let results = parse_paf_batch_to_m8(batch.into_bytes(), 29903.0);
-        let _ = results; // Just ensure no panic
+        let _ = results;
     }
 
-    // ── Additional strong equivalence tests (recommended) ─────────────────
+    // ── Strong edge-case tests (malformed tags, long lines, etc.) ─────────
 
     #[test]
     fn test_trailing_whitespace_and_empty_tags() {
         let cases = vec![
             "read6\t150\t0\t150\t+\tNC_045512.2\t29903\t100\t250\t148\t150\t60   ",
-            "read7\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60\t\tNM:i:0",     // empty field
-            "read8\t200\t0\t200\t-\tref\t2000\t0\t200\t200\t200\t60\tcg:Z:200M  ", // trailing space in last tag
-            "read9\t150\t0\t150\t+\tref\t1000\t0\t150\t150\t150\t60\t   ",         // only whitespace after last tab
+            "read7\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60\t\tNM:i:0",
+            "read8\t200\t0\t200\t-\tref\t2000\t0\t200\t200\t200\t60\tcg:Z:200M  ",
+            "read9\t150\t0\t150\t+\tref\t1000\t0\t150\t150\t150\t60\t   ",
         ];
 
         for line in cases {
@@ -577,7 +644,7 @@ mod tests {
     #[test]
     fn test_long_line_many_tabs() {
         let mut line = "longid\t100\t0\t100\t+\tlongref\t10000\t0\t100\t100\t100\t60".to_string();
-        for i in 0..40 {
+        for i in 0..50 {
             line.push_str(&format!("\ttag{i}:Z:value{i}"));
         }
         compare_parsers(&line);

--- a/src/utils/paf.rs
+++ b/src/utils/paf.rs
@@ -82,19 +82,20 @@ impl PafRecord {
     /// AVX-512 inner parser.
     /// Uses a 64-byte SIMD sweep to collect all tab positions in one pass,
     /// then indexes directly into byte slices — no iterator, no intermediate allocs.
+    /// AVX-512 inner parser — now guaranteed to match scalar exactly.
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx512f,avx512bw")]
     unsafe fn parse_line_avx512_inner(line: &str) -> Result<Self> {
         use std::arch::x86_64::*;
-        use std::arch::x86_64::__m512i;
 
-        let bytes = line.trim_end().as_bytes();
+        let trimmed = line.trim_end();
+        let bytes = trimmed.as_bytes();
         let len = bytes.len();
         if len == 0 {
             return Err(anyhow!("empty PAF line"));
         }
 
-        // ── Phase 1: collect every tab position in 64-byte SIMD chunks ──────
+        // Phase 1: Collect all tab positions
         let mut tab_pos: Vec<usize> = Vec::with_capacity(24);
         let tab_splat = _mm512_set1_epi8(b'\t' as i8);
         let mut i = 0usize;
@@ -109,7 +110,6 @@ impl PafRecord {
             }
             i += 64;
         }
-        // Scalar tail for the remaining < 64 bytes
         while i < len {
             if bytes[i] == b'\t' {
                 tab_pos.push(i);
@@ -124,16 +124,15 @@ impl PafRecord {
             ));
         }
 
-        // ── Phase 2: index into fields by tab positions ───────────────────
-        // Field n:  start = tab_pos[n-1]+1 (or 0 for n==0)
-        //           end   = tab_pos[n]      (or len for last field)
+        // Phase 2: Field extraction (exact same logic as scalar)
         macro_rules! field {
             ($n:expr) => {{
                 let start = if $n == 0 { 0 } else { tab_pos[$n - 1] + 1 };
-                let end   = if $n < tab_pos.len() { tab_pos[$n] } else { len };
+                let end = if $n < tab_pos.len() { tab_pos[$n] } else { len };
                 &bytes[start..end]
             }};
         }
+
         macro_rules! parse_u64 {
             ($n:expr, $name:literal) => {
                 lexical_parse::<u64, _>(field!($n))
@@ -141,16 +140,24 @@ impl PafRecord {
             };
         }
 
-        let qname  = std::str::from_utf8(field!(0)).map_err(|_| anyhow!("qname not UTF-8"))?.to_string();
+        let qname = std::str::from_utf8(field!(0))
+            .map_err(|_| anyhow!("qname not UTF-8"))?
+            .to_string();
+
         let qlen   = parse_u64!(1,  "qlen");
         let qstart = parse_u64!(2,  "qstart");
         let qend   = parse_u64!(3,  "qend");
+
         let strand = match field!(4).first() {
             Some(&b'+') => '+',
             Some(&b'-') => '-',
-            other => return Err(anyhow!("invalid strand byte: {:?}", other)),
+            _ => return Err(anyhow!("invalid strand")),
         };
-        let tname  = std::str::from_utf8(field!(5)).map_err(|_| anyhow!("tname not UTF-8"))?.to_string();
+
+        let tname = std::str::from_utf8(field!(5))
+            .map_err(|_| anyhow!("tname not UTF-8"))?
+            .to_string();
+
         let tlen   = parse_u64!(6,  "tlen");
         let tstart = parse_u64!(7,  "tstart");
         let tend   = parse_u64!(8,  "tend");
@@ -158,18 +165,18 @@ impl PafRecord {
         let alen   = parse_u64!(10, "alen");
         let mapq   = parse_u64!(11, "mapq");
 
-        // ── Phase 3: optional tag fields (12, 13, …) ─────────────────────
-        let n_fields = tab_pos.len() + 1;
-        let mut tags = HashMap::with_capacity(n_fields.saturating_sub(12));
-        for fi in 12..n_fields {
-            let start     = tab_pos[fi - 1] + 1;
-            let end       = if fi < tab_pos.len() { tab_pos[fi] } else { len };
+        // Phase 3: Tags — match scalar exactly
+        let mut tags = HashMap::new();
+        for fi in 12..=tab_pos.len() {  // note: <= to include last field
+            let start = tab_pos[fi - 1] + 1;  // safe because we checked tab_pos.len()
+            let end = if fi < tab_pos.len() { tab_pos[fi] } else { len };
             let tag_bytes = &bytes[start..end];
+
             if tag_bytes.is_empty() { continue; }
             if let Ok(s) = std::str::from_utf8(tag_bytes) {
-                let mut it = s.splitn(3, ':');
-                if let (Some(k), Some(_t), Some(v)) = (it.next(), it.next(), it.next()) {
-                    tags.insert(k.to_string(), v.to_string());
+                let parts: Vec<&str> = s.splitn(3, ':').collect();
+                if parts.len() == 3 {
+                    tags.insert(parts[0].to_string(), parts[2].to_string());
                 }
             }
         }
@@ -371,6 +378,31 @@ pub fn parse_paf_batch_to_m8(batch: Vec<u8>, genome_size: f64) -> Vec<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_parse_line_paf_equivalence(
+            qname in "[a-zA-Z0-9._-]{1,100}",
+            qlen in 1u64..1000000,
+            qstart in 0u64..1000000,
+            qend in 0u64..1000000,
+            strand in "[+-]",
+            tname in "[a-zA-Z0-9._-]{1,100}",
+            tlen in 1u64..1000000000,
+            tstart in 0u64..1000000000,
+            tend in 0u64..1000000000,
+            nmatch in 0u64..1000000,
+            alen in 0u64..1000000,
+            mapq in 0u8..60
+        ) {
+            let line = format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                qname, qlen, qstart, qend, strand, tname, tlen, tstart, tend, nmatch, alen, mapq
+            );
+            compare_parsers(&line);
+        }
+    }
 
     // ── helpers ────────────────────────────────────────────────────────────
 
@@ -393,13 +425,12 @@ mod tests {
     }
 
     /// Run both parsers against `line` and assert they agree.
-    /// Run both parsers against `line` and assert they agree.
     fn compare_parsers(line: &str) {
         let scalar = PafRecord::parse_line_scalar(line)
             .expect("scalar parse failed");
 
         let dispatched = PafRecord::parse_line(line)
-            .expect("dispatched parse failed");
+            .expect("dispatched (AVX-512 or scalar) parse failed");
 
         assert_records_eq(&scalar, &dispatched, line);
     }
@@ -421,11 +452,9 @@ mod tests {
     const MAX_VALUES: &str =
         "read5\t1000000\t0\t999999\t+\tNC_000001\t248956422\t0\t999999\t999000\t1000000\t60";
 
-    // A line just long enough to span two 64-byte SIMD chunks (> 64 bytes total).
     const LONG_LINE: &str =
         "long_read_id_that_is_quite_verbose_indeed\t250\t0\t250\t+\tsome_reference_sequence_name\t100000\t1000\t1250\t245\t250\t60\tcg:Z:250M\tNM:i:5";
 
-    // Trailing whitespace / CRLF should be trimmed by both parsers.
     const TRAILING_SPACE: &str =
         "read6\t150\t0\t150\t+\tNC_045512.2\t29903\t100\t250\t148\t150\t60   ";
 
@@ -439,7 +468,6 @@ mod tests {
     #[test]
     fn test_with_optional_tags() {
         compare_parsers(WITH_TAGS);
-        // Also verify tag values were parsed
         let r = PafRecord::parse_line_scalar(WITH_TAGS).unwrap();
         assert_eq!(r.tags.get("NM").map(|s| s.as_str()), Some("7"));
         assert_eq!(r.tags.get("AS").map(|s| s.as_str()), Some("255"));
@@ -477,7 +505,6 @@ mod tests {
     #[test]
     fn test_trailing_whitespace_trimmed() {
         compare_parsers(TRAILING_SPACE);
-        // Verify trailing spaces don't bleed into field values
         let r = PafRecord::parse_line_scalar(TRAILING_SPACE).unwrap();
         assert_eq!(r.qname, "read6");
         assert_eq!(r.qlen, 150);
@@ -502,23 +529,70 @@ mod tests {
     #[test]
     fn test_error_on_empty_line() {
         assert!(PafRecord::parse_line_scalar("").is_err());
-        assert!(PafRecord::parse_line("").is_err());           // ← use the dispatched version
+        assert!(PafRecord::parse_line("").is_err());
     }
 
     #[test]
     fn test_error_on_too_few_fields() {
         let short = "read1\t150\t0\t150\t+\tNC_045512.2\t29903";
         assert!(PafRecord::parse_line_scalar(short).is_err());
-        assert!(PafRecord::parse_line(short).is_err());   // use dispatched version
+        assert!(PafRecord::parse_line(short).is_err());
     }
 
     #[test]
     fn test_parse_paf_batch_to_m8_roundtrip() {
         let batch = format!("{}\n{}\n{}\n", BASIC, WITH_TAGS, REVERSE_STRAND);
         let results = parse_paf_batch_to_m8(batch.into_bytes(), 29903.0);
-        // BASIC and REVERSE_STRAND have no tname with NT:/NR: prefix → empty m8 line, filtered out
-        // WITH_TAGS also has no prefix → all three map to empty; batch returns nothing harmful
-        // Just ensure no panic and result is a Vec.
-        let _ = results;
+        let _ = results; // Just ensure no panic
+    }
+
+    // ── Additional strong equivalence tests (recommended) ─────────────────
+
+    #[test]
+    fn test_trailing_whitespace_and_empty_tags() {
+        let cases = vec![
+            "read6\t150\t0\t150\t+\tNC_045512.2\t29903\t100\t250\t148\t150\t60   ",
+            "read7\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60\t\tNM:i:0",     // empty field
+            "read8\t200\t0\t200\t-\tref\t2000\t0\t200\t200\t200\t60\tcg:Z:200M  ", // trailing space in last tag
+            "read9\t150\t0\t150\t+\tref\t1000\t0\t150\t150\t150\t60\t   ",         // only whitespace after last tab
+        ];
+
+        for line in cases {
+            compare_parsers(line);
+        }
+    }
+
+    #[test]
+    fn test_malformed_tags() {
+        let line = "read\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60\tbadtag\tgood:Z:value\tNM:i:5\tincomplete:";
+        compare_parsers(line);
+
+        let r = PafRecord::parse_line(line).unwrap();
+        assert_eq!(r.tags.get("good"), Some(&"value".to_string()));
+        assert_eq!(r.tags.get("NM"), Some(&"5".to_string()));
+        assert!(!r.tags.contains_key("badtag"));
+        assert!(!r.tags.contains_key("incomplete"));
+    }
+
+    #[test]
+    fn test_long_line_many_tabs() {
+        let mut line = "longid\t100\t0\t100\t+\tlongref\t10000\t0\t100\t100\t100\t60".to_string();
+        for i in 0..40 {
+            line.push_str(&format!("\ttag{i}:Z:value{i}"));
+        }
+        compare_parsers(&line);
+    }
+
+    #[test]
+    fn test_header_like_ids_and_special_chars() {
+        let cases = vec![
+            "read:1|with:colon\t150\t0\t150\t+\tref:seq|version.1\t1000\t0\t150\t150\t150\t60",
+            "read with space in qname\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60",
+            "read\t100\t0\t100\t+\tref\t1000\t0\t100\t100\t100\t60\tcg:Z:10M2D\tAS:i:200\tNM:i:2",
+        ];
+
+        for line in cases {
+            compare_parsers(line);
+        }
     }
 }

--- a/src/utils/paf.rs
+++ b/src/utils/paf.rs
@@ -38,7 +38,7 @@ pub struct PafRecord {
 
 impl PafRecord {
     /// Scalar parser — baseline, used on non-AVX-512 hardware.
-    fn parse_line_scalar(line: &str) -> Result<Self> {
+    pub fn parse_line_scalar(line: &str) -> Result<Self> {
         let line = line.trim_end();
         let mut fields = line.split('\t');
 

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -2025,18 +2025,18 @@ pub async fn fanout_to_channels(
     mut upstream: ReceiverStream<ParseOutput>,
     n_branches: usize,
     label: &str,
-    config: &RunConfig,           // ← added
-    data_type: StreamDataType,    // ← added
+    config: &RunConfig,
+    data_type: StreamDataType,
 ) -> Result<(Vec<mpsc::Receiver<ParseOutput>>, JoinHandle<anyhow::Result<(), anyhow::Error>>), PipelineError> {
 
     let buffer_per_branch = crate::utils::system::compute_buffer_size(
         config,
-        "fanout",                     // phase name
+        "fanout",
         data_type,
-        1.45,                         // good hot-path boost for fanout (not too aggressive)
+        1.45,
     );
 
-    let mut txs = Vec::with_capacity(n_branches);
+    let mut txs: Vec<mpsc::Sender<ParseOutput>> = Vec::with_capacity(n_branches);
     let mut rxs = Vec::with_capacity(n_branches);
 
     for _ in 0..n_branches {
@@ -2046,15 +2046,24 @@ pub async fn fanout_to_channels(
     }
 
     let label = label.to_string();
-    let router: JoinHandle<anyhow::Result<(), anyhow::Error>> = tokio::spawn(async move {
+
+    let router = tokio::spawn(async move {
         let mut count = 0usize;
+
         while let Some(item) = upstream.next().await {
             count += 1;
-            // Send to EVERY branch (never drop)
-            let sends: Vec<_> = txs.iter().map(|tx| tx.send(item.clone())).collect();
-            let _ = futures::future::join_all(sends).await;
+
+            for (branch_idx, tx) in txs.iter().enumerate() {
+                if tx.send(item.clone()).await.is_err() {
+                    return Err(anyhow!(
+                        "[fanout {}] branch {} closed unexpectedly while upstream was still producing (after {} items)",
+                        label, branch_idx, count
+                    ));
+                }
+            }
         }
-        debug!("[fanout {}] finished — forwarded {} items total", label, count);
+
+        debug!("[fanout {}] finished cleanly — forwarded {} items total", label, count);
         Ok(())
     });
 

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -843,8 +843,8 @@ pub async fn parse_fastq<R: AsyncRead + Unpin + Send + 'static>(
             let record = SequenceRecord::Fastq {
                 id,
                 desc,
-                seq: Arc::new(seq),
-                qual: Arc::new(qual),
+                seq: Bytes::from(seq),
+                qual: Bytes::from(qual),
             };
 
             if tx.send(ParseOutput::Fastq(record)).await.is_err() {
@@ -901,7 +901,7 @@ pub async fn parse_fasta<R: AsyncRead + Unpin + Send + 'static>(
                     let record = SequenceRecord::Fasta {
                         id,
                         desc: current_desc.take(),
-                        seq: Arc::new(current_seq),
+                        seq: Bytes::from(current_seq),
                     };
                     if tx.send(ParseOutput::Fasta(record)).await.is_err() {
                         return Err(anyhow!("Receiver dropped during FASTA parsing, data loss detected"));
@@ -920,7 +920,7 @@ pub async fn parse_fasta<R: AsyncRead + Unpin + Send + 'static>(
             let record = SequenceRecord::Fasta {
                 id,
                 desc: current_desc.take(),
-                seq: Arc::new(current_seq),
+                seq: Bytes::from(current_seq),
             };
             if tx.send(ParseOutput::Fasta(record)).await.is_err() {
                 return Err(anyhow!("Receiver dropped during final FASTA parsing, data loss detected"));
@@ -2142,13 +2142,13 @@ mod tests {
         let fastq = SequenceRecord::Fastq {
             id: "read1".to_string(),
             desc: Some("mate 1".to_string()),
-            seq: Arc::new(b"ATCG".to_vec()),
-            qual: Arc::new(b"IIII".to_vec()),
+            seq: Bytes::from_static(b"ATCG"),
+            qual:Bytes::from_static(b"IIII"),
         };
         let fasta = SequenceRecord::Fasta {
             id: "contig1".to_string(),
             desc: Some("assembled contig".to_string()),
-            seq: Arc::new(b"GATTACA".to_vec()),
+            seq: Bytes::from_static(b"GATTACA"),
         };
 
         assert_eq!(fastq.to_bytes()?.as_ref(), b"@read1 mate 1\nATCG\n+\nIIII\n");
@@ -2182,7 +2182,7 @@ mod tests {
             ParseOutput::Fasta(SequenceRecord::Fasta { id, desc, seq }) => {
                 assert_eq!(id, "seq1");
                 assert_eq!(desc.as_deref(), Some("first record"));
-                assert_eq!(seq.as_ref().as_slice(), b"ACGTTGCA");
+                assert_eq!(seq.as_ref(), b"ACGTTGCA");
             }
             other => panic!("Expected first FASTA record, got {:?}", other),
         }
@@ -2191,7 +2191,7 @@ mod tests {
             ParseOutput::Fasta(SequenceRecord::Fasta { id, desc, seq }) => {
                 assert_eq!(id, "seq2");
                 assert_eq!(desc, &None);
-                assert_eq!(seq.as_ref().as_slice(), b"NNNN");
+                assert_eq!(seq.as_ref(), b"NNNN");
             }
             other => panic!("Expected second FASTA record, got {:?}", other),
         }
@@ -2299,7 +2299,7 @@ mod tests {
         tx.send(ParseOutput::Fasta(SequenceRecord::Fasta {
             id: "seq1".to_string(),
             desc: Some("desc".to_string()),
-            seq: Arc::new(b"ACGT".to_vec()),
+            seq: Bytes::from_static(b"ACGT"),
         })).await?;
         tx.send(ParseOutput::Bytes(Bytes::from_static(b"ignored"))).await?;
         drop(tx);
@@ -2316,7 +2316,7 @@ mod tests {
             SequenceRecord::Fasta { id, desc, seq } => {
                 assert_eq!(id, "seq1");
                 assert_eq!(desc.as_deref(), Some("desc"));
-                assert_eq!(seq.as_ref().as_slice(), b"ACGT");
+                assert_eq!(seq.as_ref(), b"ACGT");
             }
             other => panic!("Expected FASTA record, got {:?}", other),
         }
@@ -2405,14 +2405,14 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
         let stream = tokio_stream::iter(records);
@@ -3080,9 +3080,9 @@ mod tests {
         }
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].id(), "read1");
-        assert_eq!(records[0].seq(), b"ATCG");
+        assert_eq!(records[0].seq(), Bytes::from_static(b"ATCG"));
         assert_eq!(records[1].id(), "read2");
-        assert_eq!(records[1].seq(), b"GCTA");
+        assert_eq!(records[1].seq(), Bytes::from_static(b"GCTA"));
         Ok(())
     }
 
@@ -3337,14 +3337,14 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
 
@@ -3428,8 +3428,8 @@ mod tests {
         let test_record = ParseOutput::Fastq(SequenceRecord::Fastq {
             id: "read1".to_string(),
             desc: None,
-            seq: Arc::new(b"ATCG".to_vec()),
-            qual: Arc::new(b"IIII".to_vec()),
+            seq: Bytes::from_static(b"ATCG"),
+            qual: Bytes::from_static(b"IIII"),
         });
 
         tokio::spawn(async move {
@@ -3467,26 +3467,26 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2/1".to_string(),
                 desc: None,
-                seq: Arc::new(b"CCCC".to_vec()),
-                qual: Arc::new(b"JJJJ".to_vec()),
+                seq: Bytes::from_static(b"CCCC"),
+                qual: Bytes::from_static(b"JJJJ"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2/2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GGGG".to_vec()),
-                qual: Arc::new(b"KKKK".to_vec()),
+                seq: Bytes::from_static(b"GGGG"),
+                qual: Bytes::from_static(b"KKKK"),
             }),
         ];
 
@@ -3553,14 +3553,14 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
 
@@ -3697,14 +3697,14 @@ mod tests {
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/1".to_string(),
                 desc: None,
-                seq: Arc::new(b"ATCG".to_vec()),
-                qual: Arc::new(b"IIII".to_vec()),
+                seq: Bytes::from_static(b"ATCG"),
+                qual: Bytes::from_static(b"IIII"),
             }),
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1/2".to_string(),
                 desc: None,
-                seq: Arc::new(b"GCTA".to_vec()),
-                qual: Arc::new(b"HHHH".to_vec()),
+                seq: Bytes::from_static(b"GCTA"),
+                qual: Bytes::from_static(b"HHHH"),
             }),
         ];
 

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -30,6 +30,7 @@ use std::os::unix::fs::PermissionsExt;
 use tokio::fs::{self, set_permissions};
 use std::fs::Permissions;
 use bytes::Bytes;
+use which;
 
 use crate::utils::fastx::{SequenceRecord, parse_header};
 use crate::config::defs::{PipelineError, StreamDataType, DIAMOND_TAG, MMSEQS_TAG, SPADES_TAG};
@@ -339,6 +340,33 @@ where
 }
 
 
+/// Returns the binary + arguments to use, optionally wrapped with numactl.
+///
+/// This is the single source of truth for numactl policy.
+/// Falls back gracefully if numactl is not installed.
+fn build_command_with_numa(
+    config: &RunConfig,
+    cmd_tag: &str,
+    args: Vec<String>,
+) -> (String, Vec<String>) {
+    let should_use = cfg!(target_os = "linux")
+        && config.max_cores >= 64
+        && matches!(cmd_tag, MMSEQS_TAG | DIAMOND_TAG | SPADES_TAG);
+
+    if should_use {
+        if which::which("numactl").is_ok() {
+            let mut final_args = vec!["--interleave=all".to_string(), cmd_tag.to_string()];
+            final_args.extend(args);
+            debug!("Using numactl --interleave=all for {}", cmd_tag);
+            return ("numactl".to_string(), final_args);
+        } else {
+            warn!("numactl not found — running {} without NUMA interleave", cmd_tag);
+        }
+    }
+
+    (cmd_tag.to_string(), args)
+}
+
 /// Asynchronously spawn an external process and feed it a stream as stdin.
 /// Capture stdout and return from function.
 ///
@@ -378,32 +406,33 @@ pub async fn stream_to_cmd(
         data_type,
         1.8, // 1.0 = normal, 1.5–2.0 for very hot paths later
     );
+    let batch_size_bytes = writer_capacity / 4;
 
-    let batch_size_bytes = writer_capacity / 4; // keep ~4:1 batching ratio
+    let (binary, final_args) = build_command_with_numa(config.as_ref(), cmd_tag, args);
 
-    let cmd_tag_owned = cmd_tag.to_string();
-    let cmd_tag_err_owned = cmd_tag.to_string();
-    let stderr_log_path_clone = stderr_log_path.clone();
-
-    let mut child = Command::new(&cmd_tag_owned)
-        .args(&args)
+    let mut child = Command::new(&binary)
+        .args(&final_args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .map_err(|e| anyhow!("Failed to spawn {}: {}", cmd_tag_owned, e))?;
+        .map_err(|e| anyhow!("Failed to spawn {}: {}", cmd_tag, e))?;
 
     let stdin = child
         .stdin
         .take()
-        .ok_or_else(|| anyhow!("Failed to open stdin for {}", cmd_tag_owned))?;
+        .ok_or_else(|| anyhow!("Failed to open stdin for {}", cmd_tag))?;
     let stderr = child
         .stderr
         .take()
-        .ok_or_else(|| anyhow!("Failed to capture stderr for {}", cmd_tag_owned))?;
+        .ok_or_else(|| anyhow!("Failed to capture stderr for {}", cmd_tag))?;
 
     let child = Arc::new(tokio::sync::Mutex::new(child));
     let child_clone = child.clone();
+
+    let cmd_tag_owned = cmd_tag.to_string();
+    let cmd_tag_err_owned = cmd_tag.to_string();
+    let stderr_log_path_clone = stderr_log_path.clone();
 
     let stdin_task = tokio::spawn(async move {
         let mut writer = BufWriter::with_capacity(writer_capacity, stdin);
@@ -578,24 +607,9 @@ pub async fn spawn_cmd(
 
     let cmd_tag_owned = cmd_tag.to_string();
 
-    // === NUMA SUPPORT - ONLY for tools that benefit ===
-    let (binary, final_args) = if should_use_numactl(config.as_ref(), cmd_tag) {
-        let mut numa_args = vec!["--interleave=all".to_string(), cmd_tag_owned.clone()];
-        numa_args.extend(args);
-        debug!("spawn_cmd: Prepended numactl --interleave=all for {}", cmd_tag);
-        ("numactl", numa_args)
-    } else {
-        ("", args)   // empty string = use original binary
-    };
+    let (binary, final_args) = build_command_with_numa(config.as_ref(), cmd_tag, args);
 
-    eprintln!("[{} cmd]: {}", cmd_tag, final_args.join(" "));
-
-    // Use the correct binary
-    let mut child = if binary.is_empty() {
-        Command::new(&cmd_tag_owned)
-    } else {
-        Command::new(binary)
-    }
+    let mut child = Command::new(&binary)
         .args(&final_args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -603,14 +617,14 @@ pub async fn spawn_cmd(
         .spawn()
         .map_err(|e| anyhow!("Failed to spawn {}: {}", cmd_tag_owned, e))?;
 
-    let stderr_task = {
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| anyhow!("Failed to capture stderr for {}", cmd_tag_owned))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("Failed to capture stderr for {}", cmd_tag_owned))?;
 
-        let cmd_tag_clone = cmd_tag_owned.clone();
+    let stderr_task = {
         let stderr_log_path_clone = stderr_log_path.clone();
+        let cmd_tag_clone = cmd_tag_owned.clone();
 
         tokio::spawn(async move {
             let mut reader = BufReader::with_capacity(1024 * 1024, stderr);

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -660,15 +660,13 @@ pub async fn ensure_transparent_hugepages(config: &RunConfig) -> Result<()> {
         return Ok(());
     }
 
-    info!("Configuring Transparent Huge Pages (madvise mode) for large EPYC node...");
+    info!("Configuring Transparent Huge Pages for large linux node...");
 
-    // We only touch these two. defrag is left at the system default.
     let paths = [
         "/sys/kernel/mm/transparent_hugepage/enabled",
         "/sys/kernel/mm/transparent_hugepage/shmem_enabled",
+        "/sys/kernel/mm/transparent_hugepage/defrag",
     ];
-
-    let target = "madvise";
 
     for path in &paths {
         let current = match tokio::fs::read_to_string(path).await {
@@ -679,19 +677,38 @@ pub async fn ensure_transparent_hugepages(config: &RunConfig) -> Result<()> {
             }
         };
 
-        // Already correct?
-        if current.contains("[madvise]") || current == target {
-            debug!("{} already set to madvise", path);
-            continue;
-        }
-
-        if let Err(e) = tokio::fs::write(path, target).await {
-            warn!("Failed to set {} to '{}': {}", path, target, e);
+        // Choose best supported value
+        let target = if path.ends_with("/defrag") {
+            // Prefer defer+madvise on modern kernels, fall back to madvise
+            if current.contains("[defer+madvise]") {
+                continue; // already optimal
+            }
+            "defer+madvise"
         } else {
-            info!("Set {} → {}", path, target);
+            if current.contains("[madvise]") {
+                continue;
+            }
+            "madvise"
+        };
+
+        match tokio::fs::write(path, target).await {
+            Ok(_) => info!("Set {} → {}", path, target),
+            Err(e) => {
+                if path.ends_with("/defrag") && target == "defer+madvise" {
+                    // Fallback for older kernels
+                    warn!("defer+madvise not supported on this kernel, falling back to madvise");
+                    if let Err(e2) = tokio::fs::write(path, "madvise").await {
+                        warn!("Failed to set {} to madvise: {}", path, e2);
+                    } else {
+                        info!("Set {} → madvise (fallback)", path);
+                    }
+                } else {
+                    warn!("Failed to set {} to '{}': {}", path, target, e);
+                }
+            }
         }
     }
 
-    info!("THP configuration complete (mode: madvise)");
+    info!("THP configuration complete (mode: madvise + safe defrag)");
     Ok(())
 }

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -644,56 +644,54 @@ pub fn detect_simd_level() -> SimdLevel {
     }
 }
 
-/// Ensures Transparent Huge Pages are enabled in the best mode for MMseqs/Diamond.
-/// Should be called early in pipeline startup on big Linux nodes.
+/// Configures Transparent Huge Pages (THP) safely for large EPYC nodes.
+///
+/// We deliberately use `madvise` instead of `always`. Forcing `always` globally
+/// interacts very badly with GNU sort (when using large `-S` buffers) and some
+/// other tools, causing severe memory fragmentation and massive slowdowns on
+/// machines with ≥ 512 GiB RAM.
+///
+/// `madvise` is the safe default: it lets the application (and libraries) opt
+/// into huge pages where it actually helps (large allocations, mmseqs, etc.)
+/// without punishing tools like `sort`, `samtools sort`, etc.
 pub async fn ensure_transparent_hugepages(config: &RunConfig) -> Result<()> {
     if !cfg!(target_os = "linux") || config.max_cores < 64 {
-        debug!("THP optimization skipped (not a large Linux node)");
+        debug!("THP configuration skipped (not a large Linux node)");
         return Ok(());
     }
 
-    info!("Ensuring Transparent Huge Pages (THP) are optimized for large EPYC nodes...");
+    info!("Configuring Transparent Huge Pages (madvise mode) for large EPYC node...");
 
+    // We only touch these two. defrag is left at the system default.
     let paths = [
         "/sys/kernel/mm/transparent_hugepage/enabled",
         "/sys/kernel/mm/transparent_hugepage/shmem_enabled",
-        "/sys/kernel/mm/transparent_hugepage/defrag",
     ];
 
-    let target = "always";
+    let target = "madvise";
 
     for path in &paths {
         let current = match tokio::fs::read_to_string(path).await {
             Ok(s) => s.trim().to_string(),
             Err(e) => {
-                warn!("Could not read {}: {}", path, e);
+                debug!("Could not read {}: {}", path, e);
                 continue;
             }
         };
 
-        if current.contains(target) {
-            debug!("{} already set to {}", path, target);
+        // Already correct?
+        if current.contains("[madvise]") || current == target {
+            debug!("{} already set to madvise", path);
             continue;
         }
 
-        // Try to set it
         if let Err(e) = tokio::fs::write(path, target).await {
-            warn!("Failed to write '{}' to {}: {}", target, path, e);
-            // Non-fatal — continue
+            warn!("Failed to set {} to '{}': {}", path, target, e);
         } else {
-            info!("Set {} = {}", path, target);
+            info!("Set {} → {}", path, target);
         }
     }
 
-    // Also encourage defrag
-    let _ = tokio::fs::write("/sys/kernel/mm/transparent_hugepage/defrag", "always").await;
-
-    // Optional: drop caches to encourage promotion
-    if config.max_cores >= 128 {
-        let _ = tokio::fs::write("/proc/sys/vm/drop_caches", "3").await;
-        info!("Dropped page cache to encourage hugepage promotion");
-    }
-
-    info!("THP optimization complete (mode: always)");
+    info!("THP configuration complete (mode: madvise)");
     Ok(())
 }


### PR DESCRIPTION
- **reowrked process_assembly: incorporated the spades launch directly. simplified temp dir, so it all in one place. removed coverage_json_path andn coverage_summary_csv_path from CoverageOutputs as they are not generated at the same time the structure is made. no need aofr  aseparate "ram" contigs.fasta as the working copy will be in tem.**
- **sort buffer was far too large for sort_m8_by_read_id - reduced to 8G/32G**
- **ensure non_host_temp_dir lives to end of pipe;ine run**
- **THP shifting to madvise**
- **build_command_with_numa using which for more defensive use of numactl.**
- **fix for -o bug in bt2 single ended output. defaulting also to exlicit y \1 \2 style read labelling on for paired and single for increased determinacy**
- **hisat2_filter: fixed SE coutning path. fixed Always fanout for count + fastq. dynamix threads for sorting. Always -N for clarity.**
- **blast_contigs: makeblastdb must complete prior to blast running. also added index check**
- **early_blast_exit for retrining emply blast results. added a check for makeblastdb failure to make index that gracefully calls the above and lets rest of pipeline run**
- **adding defrag defebnsively to THP. doing a check for the better defer+madvide and falling back to madvbise if it doenst work**
- **SequenceRecord and its implemention converted so that seq and qual use the Bytes crate for fast zero copy. all tests and dependent functions changed to match.**
- **fabout to channel makes noisy errors ona  premature branch drop. Also avoiding some allocation pressure by removing a Vec crateion in the send line.**
