### PR TITLE
T junction replace

### DIFF
--- a/src/pipelines/consensus_genome.rs
+++ b/src/pipelines/consensus_genome.rs
@@ -21,7 +21,7 @@ use crate::utils::streams::ParseOutput;
 use crate::utils::command::{generate_cli, check_versions};
 use crate::utils::file::{file_path_manipulator, write_parse_output_to_temp_fifo, validate_file_inputs, choose_temp_dir};
 use crate::utils::fastx::{read_fastq, parse_and_filter_fastq_id, concatenate_paired_reads, parse_byte_stream_to_fastq};
-use crate::utils::streams::{t_junction, stream_to_cmd, parse_child_output, ChildStream, ParseMode, stream_to_file, spawn_cmd, parse_fastq, parse_bytes, y_junction, join_with_error_handling};
+use crate::utils::streams::{fanout_to_channels, stream_to_cmd, parse_child_output, ChildStream, ParseMode, stream_to_file, spawn_cmd, parse_fastq, parse_bytes, y_junction, join_with_error_handling};
 use crate::config::defs::{PipelineError, StreamDataType, PIGZ_TAG, MINIMAP2_TAG, SAMTOOLS_TAG, SamtoolsSubcommand, KRAKEN2_TAG, BCFTOOLS_TAG, BcftoolsSubcommand, MAFFT_TAG, QUAST_TAG, SEQKIT_TAG, SeqkitSubcommand, PairingMode};
 use crate::utils::command::samtools::SamtoolsConfig;
 use crate::utils::command::kraken2::Kraken2Config;
@@ -104,19 +104,16 @@ async fn validate_input(
     let val_rx_stream = ReceiverStream::new(rx);
 
     // Split the byte stream for output and quast write
-    let (val_streams, _val_done_rx) = t_junction(
+    let (val_streams, val_router_handle) = fanout_to_channels(
         val_rx_stream,
         2,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
-        StreamDataType::IlluminaFastq,  // Semantically FASTQ bytes
-        "validate_input".to_string(),
-        None,
+        "validate_input",
+        &config,
+        StreamDataType::IlluminaFastq,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
+
+    cleanup_tasks.push(val_router_handle);
 
     if val_streams.len() < 2 {
         return Err(PipelineError::EmptyStream);
@@ -337,21 +334,16 @@ async fn align_to_host(
     let samtools_out_stream_fastq = ReceiverStream::new(samtools_out_stream_fastq);
 
     // Split FASTQ byte stream for output, file write, count, and check
-    let (host_streams, host_done_rx) = t_junction(
+    let (host_streams, host_router_handle) = fanout_to_channels(
         samtools_out_stream_fastq,
         4,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "align_to_host",
+        &config,
         StreamDataType::JustBytes,
-        "align_to_host".to_string(),
-        None,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    cleanup_receivers.push(host_done_rx);
+    cleanup_tasks.push(host_router_handle);
 
     // Consume Vec to get Receivers
     let mut streams_iter = host_streams.into_iter();
@@ -477,24 +469,19 @@ async fn process_ercc(
         "_",
     );
 
-    let (ercc_streams, ercc_done_rx) = t_junction(
+    let (ercc_streams, ercc_router_handle) = fanout_to_channels(
         input_stream,
         2,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "process_ercc_bypass",
+        &config,
         StreamDataType::JustBytes,
-        "process_ercc_bypass".to_string(),
-        None,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
     let mut streams_iter = ercc_streams.into_iter();
     let bypass_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let alignment_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
-    cleanup_receivers.push(ercc_done_rx);
+    cleanup_tasks.push(ercc_router_handle);
 
     let mut minimap2_options = HashMap::new();
     match config.args.technology {
@@ -554,21 +541,16 @@ async fn process_ercc(
 
 
     // Split SAM stream for check and further processing
-    let (sam_streams, sam_done_rx) = t_junction(
+    let (sam_streams, sam_router_handle) = fanout_to_channels(
         ReceiverStream::new(minimap2_out_stream),
         2,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "process_ercc_sam",
+        &config,
         StreamDataType::JustBytes,
-        "process_ercc_empty_check".to_string(),
-        None,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    cleanup_receivers.push(sam_done_rx);
+    cleanup_tasks.push(sam_router_handle);
     let mut sam_streams_iter = sam_streams.into_iter();
     let sam_check_stream = sam_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let sam_view_stream = sam_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -726,21 +708,16 @@ async fn process_ercc(
     };
 
 
-    let (stats_streams, stats_done_rx) = t_junction(
+    let (stats_streams, stats_router_handle) = fanout_to_channels(
         ReceiverStream::new(stats_samtools_out_stream),
         2,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "process_ercc_stats",
+        &config,
         StreamDataType::JustBytes,
-        "process_ercc_stats".to_string(),
-        None,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    cleanup_receivers.push(stats_done_rx);
+    cleanup_tasks.push(stats_router_handle);
     let mut stats_streams_iter = stats_streams.into_iter();
     let stats_file_stream = stats_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let stats_parse_stream = stats_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -916,7 +893,7 @@ async fn filter_with_kraken(
 
     let filtered_stream = ReceiverStream::new(parse_output_rx);
 
-    // Before t_junction, split for check
+    // Before fanout_to_channels, split for check
     let (check_tx, mut check_rx) = mpsc::channel(1);
     let (forward_tx, forward_rx) = mpsc::channel(config.base_buffer_size);
     let check_split_task = tokio::spawn(async move {
@@ -953,21 +930,16 @@ async fn filter_with_kraken(
     let filtered_stream = ReceiverStream::new(forward_rx);
 
     // Split stream for output and compression
-    let (kraken_streams, kraken_done_rx) = t_junction(
+    let (kraken_streams, kraken_router_handle) = fanout_to_channels(
         filtered_stream,
         2, // Only two streams now
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "filter_reads_output",
+        &config,
         StreamDataType::IlluminaFastq,
-        "filter_reads_output".to_string(),
-        None,
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    let cleanup_receivers = vec![kraken_done_rx];
+    cleanup_tasks.push(kraken_router_handle);
     let mut streams_iter = kraken_streams.into_iter();
     let kraken_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let kraken_file_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -1018,6 +990,7 @@ async fn filter_with_kraken(
     });
     cleanup_tasks.push(cleanup_pipe_task);
 
+    let cleanup_receivers: Vec<oneshot::Receiver<Result<(), anyhow::Error>>> = vec![];
     Ok((ReceiverStream::new(kraken_output_stream), cleanup_tasks, cleanup_receivers))
 }
 
@@ -1167,21 +1140,16 @@ async fn align_to_target(
         "_",
     );
 
-    let (sam_streams, sam_done_rx) = t_junction(
+    let (sam_streams, sam_router_handle) = fanout_to_channels(
         samtools_sort_out_stream,
         3,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "align_to_target",
+        &config,
         StreamDataType::JustBytes,
-        "align_to_target".to_string(),
-        None
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    cleanup_receivers.push(sam_done_rx);
+    cleanup_tasks.push(sam_router_handle);
     let mut streams_iter = sam_streams.into_iter();
     let sam_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let sam_file_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -1386,20 +1354,15 @@ async fn generate_consensus(
 
     let samtools_consensus_out_stream = ReceiverStream::new(samtools_consensus_out_stream);
 
-    let (consensus_streams, consensus_done_rx) = t_junction(
+    let (consensus_streams, consensus_router_handle) = fanout_to_channels(
         samtools_consensus_out_stream,
         3,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "generate_consensus",
+        &config,
         StreamDataType::JustBytes,
-        "generate_consensus".to_string(),
-        None,
-    ).await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+    ).await?;
 
-    cleanup_receivers.push(consensus_done_rx);
+    cleanup_tasks.push(consensus_router_handle);
     let mut streams_iter = consensus_streams.into_iter();
     let consensus_realign_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let consensus_stats_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -1535,21 +1498,16 @@ async fn call_variants(
     };
     let bcftools_call_out_stream = ReceiverStream::new(bcftools_call_out_stream);
 
-    let (vcf_streams, vcf_done_rx) = t_junction(
+    let (vcf_streams, vcf_router_handle) = fanout_to_channels(
         bcftools_call_out_stream,
         2,
-        config.base_buffer_size,
-        config.args.stall_threshold,
-        None,
-        config.base_backpressure_pause,
+        "call_variants",
+        &config,
         StreamDataType::JustBytes,
-        "call_variants".to_string(),
-        None
     )
-        .await
-        .map_err(|_| PipelineError::StreamDataDropped)?;
+        .await?;
 
-    cleanup_receivers.push(vcf_done_rx);
+    cleanup_tasks.push(vcf_router_handle);
 
     let mut streams_iter = vcf_streams.into_iter();
     let vcf_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -2121,20 +2079,15 @@ pub async fn run(config: Arc<RunConfig>) -> Result<(), PipelineError> {
             align_bam_path = Some(align_bam_path_inner);
 
             // Split SAM streams for bypass, stats, etc
-            let (align_sam_streams, align_sam_done_rx) = t_junction(
+            let (align_sam_streams, align_sam_router_handle) = fanout_to_channels(
                 sam_output_stream,
                 4,
-                config.base_buffer_size,
-                config.args.stall_threshold,
-                None,
-                config.base_backpressure_pause,
+                "pipeline_aligned_sam_split",
+                &config,
                 StreamDataType::JustBytes,
-                "pipeline_aligned_sam_split".to_string(),
-                None,
             )
-                .await
-                .map_err(|_| PipelineError::StreamDataDropped)?;
-            cleanup_receivers.push(align_sam_done_rx);
+                .await?;
+            cleanup_tasks.push(align_sam_router_handle);
             let mut align_streams_iter = align_sam_streams.into_iter();
             let align_sam_output_stream = align_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
             let align_sam_call_stream = align_streams_iter.next().ok_or(PipelineError::EmptyStream)?;

--- a/src/pipelines/consensus_genome.rs
+++ b/src/pipelines/consensus_genome.rs
@@ -79,7 +79,7 @@ async fn validate_input(
     out_dir: &PathBuf,
 ) -> Result<(ReceiverStream<ParseOutput>, Vec<JoinHandle<Result<(), anyhow::Error>>>, Vec<oneshot::Receiver<Result<(), anyhow::Error>>>, JoinHandle<anyhow::Result<ReadStats, anyhow::Error>>), PipelineError> {
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
     let validated_interleaved_file_path = file_path_manipulator(
         &PathBuf::from(&sample_base_buf),
         Some(out_dir),
@@ -113,7 +113,7 @@ async fn validate_input(
     )
         .await?;
 
-    cleanup_tasks.push(val_router_handle);
+    cleanup_receivers.push(val_router_handle);
 
     if val_streams.len() < 2 {
         return Err(PipelineError::EmptyStream);
@@ -343,7 +343,7 @@ async fn align_to_host(
     )
         .await?;
 
-    cleanup_tasks.push(host_router_handle);
+    cleanup_receivers.push(host_router_handle);
 
     // Consume Vec to get Receivers
     let mut streams_iter = host_streams.into_iter();
@@ -481,7 +481,7 @@ async fn process_ercc(
     let mut streams_iter = ercc_streams.into_iter();
     let bypass_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let alignment_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
-    cleanup_tasks.push(ercc_router_handle);
+    cleanup_receivers.push(ercc_router_handle);
 
     let mut minimap2_options = HashMap::new();
     match config.args.technology {
@@ -550,7 +550,7 @@ async fn process_ercc(
     )
         .await?;
 
-    cleanup_tasks.push(sam_router_handle);
+    cleanup_receivers.push(sam_router_handle);
     let mut sam_streams_iter = sam_streams.into_iter();
     let sam_check_stream = sam_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let sam_view_stream = sam_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -717,7 +717,7 @@ async fn process_ercc(
     )
         .await?;
 
-    cleanup_tasks.push(stats_router_handle);
+    cleanup_receivers.push(stats_router_handle);
     let mut stats_streams_iter = stats_streams.into_iter();
     let stats_file_stream = stats_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let stats_parse_stream = stats_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -764,6 +764,7 @@ async fn filter_with_kraken(
     PipelineError,
 > {
     let mut cleanup_tasks = vec![];
+    let mut cleanup_receivers = Vec::new();
 
     // Parse the byte stream into Fastq records
     let (parse_rx, parse_task) = parse_byte_stream_to_fastq(
@@ -939,7 +940,7 @@ async fn filter_with_kraken(
     )
         .await?;
 
-    cleanup_tasks.push(kraken_router_handle);
+    cleanup_receivers.push(kraken_router_handle);
     let mut streams_iter = kraken_streams.into_iter();
     let kraken_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let kraken_file_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -990,7 +991,6 @@ async fn filter_with_kraken(
     });
     cleanup_tasks.push(cleanup_pipe_task);
 
-    let cleanup_receivers: Vec<oneshot::Receiver<Result<(), anyhow::Error>>> = vec![];
     Ok((ReceiverStream::new(kraken_output_stream), cleanup_tasks, cleanup_receivers))
 }
 
@@ -1149,7 +1149,7 @@ async fn align_to_target(
     )
         .await?;
 
-    cleanup_tasks.push(sam_router_handle);
+    cleanup_receivers.push(sam_router_handle);
     let mut streams_iter = sam_streams.into_iter();
     let sam_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let sam_file_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -1362,7 +1362,7 @@ async fn generate_consensus(
         StreamDataType::JustBytes,
     ).await?;
 
-    cleanup_tasks.push(consensus_router_handle);
+    cleanup_receivers.push(consensus_router_handle);
     let mut streams_iter = consensus_streams.into_iter();
     let consensus_realign_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
     let consensus_stats_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -1507,7 +1507,7 @@ async fn call_variants(
     )
         .await?;
 
-    cleanup_tasks.push(vcf_router_handle);
+    cleanup_receivers.push(vcf_router_handle);
 
     let mut streams_iter = vcf_streams.into_iter();
     let vcf_output_stream = streams_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -2087,7 +2087,7 @@ pub async fn run(config: Arc<RunConfig>) -> Result<(), PipelineError> {
                 StreamDataType::JustBytes,
             )
                 .await?;
-            cleanup_tasks.push(align_sam_router_handle);
+            cleanup_receivers.push(align_sam_router_handle);
             let mut align_streams_iter = align_sam_streams.into_iter();
             let align_sam_output_stream = align_streams_iter.next().ok_or(PipelineError::EmptyStream)?;
             let align_sam_call_stream = align_streams_iter.next().ok_or(PipelineError::EmptyStream)?;

--- a/src/pipelines/short_read_mngs.rs
+++ b/src/pipelines/short_read_mngs.rs
@@ -297,7 +297,7 @@ async fn validate_input(
     out_dir: &PathBuf,
 ) -> anyhow::Result<(ReceiverStream<ParseOutput>, Vec<JoinHandle<anyhow::Result<(), anyhow::Error>>>, Vec<oneshot::Receiver<anyhow::Result<(), anyhow::Error>>>, JoinHandle<anyhow::Result<u64, anyhow::Error>>, JoinHandle<anyhow::Result<ReadStats, anyhow::Error>>), PipelineError> {
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
 
 
     let validated_interleaved_file_path = file_path_manipulator(
@@ -327,7 +327,7 @@ async fn validate_input(
     let val_rx_stream = ReceiverStream::new(rx);
 
     // Split the byte stream for fastp and write
-    let (val_streams, val_router_handle) = fanout_to_channels(
+    let (val_streams, val_router_done_rx) = fanout_to_channels(
         val_rx_stream,
         2,
         "validate_input",
@@ -337,7 +337,7 @@ async fn validate_input(
         .await
         .map_err(|_| PipelineError::StreamDataDropped)?;
 
-    cleanup_tasks.push(val_router_handle);
+    cleanup_receivers.push(val_router_done_rx);
 
     let mut val_streams_iter = val_streams.into_iter();
 
@@ -400,7 +400,7 @@ async fn bowtie2_align_and_sort_stream(
 ), PipelineError> {
 
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
 
     let temp_dir = choose_temp_dir(
         config.input_size,
@@ -481,7 +481,7 @@ async fn bowtie2_align_and_sort_stream(
     // split stream
     // ─────────────────────────────
 
-    let (streams, router_handle) = fanout_to_channels(
+    let (streams, router_done_rx) = fanout_to_channels(
         ReceiverStream::new(sorted_bam_stream),
         3,
         "bt2_split",
@@ -492,7 +492,7 @@ async fn bowtie2_align_and_sort_stream(
         .map_err(|_| PipelineError::StreamDataDropped)?;
 
     // track the task instead of a oneshot receiver
-    cleanup_tasks.push(router_handle);
+    cleanup_receivers.push(router_done_rx);
 
     let mut it = streams.into_iter();
 
@@ -798,7 +798,7 @@ async fn hisat2_filter(
 ), PipelineError> {
 
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
 
     // PAIRED-END PATH
     if paired {
@@ -999,7 +999,7 @@ async fn hisat2_filter(
     // 3. Always fanout for count + fastq (reuse existing fanout + splits pattern).
     //    Write tee only if output_bam_path requested. Keeps streaming when None.
     let num_tees = if output_bam_path.is_some() { 3 } else { 2 };
-    let (streams, router) = fanout_to_channels(
+    let (streams, hisat2_bam_split_done_rx) = fanout_to_channels(
         ReceiverStream::new(sorted_bam_stream),
         num_tees,
         "hisat2_bam_split",
@@ -1022,7 +1022,7 @@ async fn hisat2_filter(
         ).await?;
         cleanup_tasks.push(write_task);
     }
-    cleanup_tasks.push(router);
+    cleanup_receivers.push(hisat2_bam_split_done_rx);
 
     let fastq_input_stream = ReceiverStream::new(fastq_stream);
 
@@ -1124,7 +1124,7 @@ async fn fastp_qc(
     input_stream: ReceiverStream<ParseOutput>,
 ) -> Result<(ReceiverStream<ParseOutput>,  Vec<JoinHandle<Result<(), anyhow::Error>>>, Vec<oneshot::Receiver<Result<(), anyhow::Error>>>, oneshot::Receiver<Result<u64, anyhow::Error>>), PipelineError>{
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
 
     let qc_fastp_config_view = FastpConfig {
 
@@ -1184,7 +1184,7 @@ async fn fastp_qc(
     // Tee the byte stream for counting
     let tee_count_input = ReceiverStream::new(qc_fastp_out_stream);
 
-    let (tee_count_streams, tee_count_router_handle) = fanout_to_channels(
+    let (tee_count_streams, tee_count_router_done_rx) = fanout_to_channels(
         tee_count_input,
         2,
         "fastp_count",
@@ -1198,7 +1198,7 @@ async fn fastp_qc(
         })?;
 
     // track the task instead of oneshot receiver
-    cleanup_tasks.push(tee_count_router_handle);
+    cleanup_receivers.push(tee_count_router_done_rx);
 
     let mut tee_count_streams_iter = tee_count_streams.into_iter();
 
@@ -1515,7 +1515,7 @@ async fn minimap2_filter(
     PipelineError,
 > {
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
     let mut temp_dirs: Vec<TempDir> = Vec::new();
     let mut named_temp_files: Vec<NamedTempFile> = Vec::new();
 
@@ -1660,7 +1660,7 @@ async fn minimap2_filter(
 
     let bam_rx_stream = ReceiverStream::new(samtools_sort_out_stream);
 
-    let (bam_streams, bam_router_handle) = fanout_to_channels(
+    let (bam_streams, bam_router_done_rx) = fanout_to_channels(
         bam_rx_stream,
         num_tees,
         "minimap2_bam_split",
@@ -1671,7 +1671,7 @@ async fn minimap2_filter(
         .map_err(|_| PipelineError::StreamDataDropped)?;
 
     // track task instead of oneshot receiver
-    cleanup_tasks.push(bam_router_handle);
+    cleanup_receivers.push(bam_router_done_rx);
 
     let mut bam_streams_iter = bam_streams.into_iter();
 
@@ -2542,6 +2542,10 @@ pub async fn paf_to_m8(
     Vec<JoinHandle<Result<(), anyhow::Error>>>,
     Vec<oneshot::Receiver<Result<(), anyhow::Error>>>,
 )> {
+
+    let mut cleanup_tasks: Vec<JoinHandle<Result<(), anyhow::Error>>> = Vec::new();
+    let mut cleanup_receivers: Vec<oneshot::Receiver<Result<(), anyhow::Error>>> = Vec::new();
+
     let genome_size = config.args.nt_db_size as f64;
 
     let paf_record_count = Arc::new(AtomicUsize::new(0));
@@ -2580,7 +2584,7 @@ pub async fn paf_to_m8(
     // Split the converted stream immediately; no extra intermediate mpsc queue.
     use tokio_stream::wrappers::ReceiverStream;
 
-    let (streams, router_handle) = fanout_to_channels(
+    let (streams, paf_to_m8_stream_done_rx) = fanout_to_channels(
         batched_stream,
         2,
         "paf_to_m8_stream",
@@ -2589,6 +2593,7 @@ pub async fn paf_to_m8(
     )
         .await
         .map_err(|_| PipelineError::StreamDataDropped)?;
+    cleanup_receivers.push(paf_to_m8_stream_done_rx);
 
 
     let mut streams = streams;
@@ -2610,6 +2615,7 @@ pub async fn paf_to_m8(
     )
         .await
         .map_err(|e| PipelineError::IOError(e.to_string()))?;
+    cleanup_tasks.push(write_task);
 
     let paf_total = paf_record_count.load(std::sync::atomic::Ordering::Relaxed);
     let m8_total = m8_line_count.load(std::sync::atomic::Ordering::Relaxed);
@@ -2621,8 +2627,8 @@ pub async fn paf_to_m8(
 
     Ok((
         main_stream,
-        vec![write_task, router_handle],
-        vec![],
+        cleanup_tasks,
+        cleanup_receivers,
     ))
 }
 
@@ -2841,7 +2847,7 @@ pub async fn call_hits_m8(
 ), PipelineError> {
     let worker_count = concurrency.max(1);
     let mut cleanup_tasks: Vec<JoinHandle<Result<()>>> = Vec::new();
-    let cleanup_receivers: Vec<oneshot::Receiver<Result<()>>> = Vec::new();
+    let mut cleanup_receivers: Vec<oneshot::Receiver<Result<()>>> = Vec::new();
 
     info!(
         "[call_hits_m8:{}] STARTING STREAMING VERSION — workers={}, min_aln_len={}",
@@ -3088,7 +3094,7 @@ pub async fn call_hits_m8(
     cleanup_tasks.push(coordinator_handle);
 
     let dedup_stream = ReceiverStream::new(dedup_rx);
-    let (dedup_branches, dedup_router_handle) = fanout_to_channels(
+    let (dedup_branches, dedup_router_done_rx) = fanout_to_channels(
         dedup_stream,
         2,
         "call_hits_m8_dedup",
@@ -3099,7 +3105,7 @@ pub async fn call_hits_m8(
         .map_err(|e| PipelineError::IOError(e.to_string()))?;
 
     // track router task (replaces cleanup_receivers)
-    cleanup_tasks.push(dedup_router_handle);
+    cleanup_receivers.push(dedup_router_done_rx);
 
     let mut dedup_branches = dedup_branches.into_iter();
 
@@ -3128,7 +3134,7 @@ pub async fn call_hits_m8(
     cleanup_tasks.push(call_file_write_task);
 
     let summary_stream = ReceiverStream::new(summary_rx);
-    let (summary_branches, summary_router_handle) = fanout_to_channels(
+    let (summary_branches, summary_router_done_rx) = fanout_to_channels(
         summary_stream,
         2,
         "call_hits_m8_summary",
@@ -3139,7 +3145,7 @@ pub async fn call_hits_m8(
         .map_err(|e| PipelineError::IOError(e.to_string()))?;
 
     // track router task instead of oneshot receiver
-    cleanup_tasks.push(summary_router_handle);
+    cleanup_receivers.push(summary_router_done_rx);
 
     let mut summary_branches = summary_branches.into_iter();
 
@@ -4392,7 +4398,7 @@ pub async fn process_assembly(
     TempDir,
 ), PipelineError> {
     let mut cleanup_tasks = Vec::new();
-    let cleanup_receivers = Vec::new();
+    let mut cleanup_receivers = Vec::new();
     let mut temp_files: Vec<NamedTempFile> = Vec::new();
 
 
@@ -4718,7 +4724,7 @@ pub async fn process_assembly(
 
     use tokio_stream::wrappers::ReceiverStream;
 
-    let (non_host_streams, non_host_router_handle) = fanout_to_channels(
+    let (non_host_streams, non_host_done_rx) = fanout_to_channels(
         ReceiverStream::new(samtools_sort_out_stream),
         3,
         "process_assembly_sam",
@@ -4729,7 +4735,7 @@ pub async fn process_assembly(
         .map_err(|_| PipelineError::StreamDataDropped)?;
 
     // track task
-    cleanup_tasks.push(non_host_router_handle);
+    cleanup_receivers.push(non_host_done_rx);
 
     let mut non_host_streams_iter = non_host_streams.into_iter();
 
@@ -7792,7 +7798,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         out_dir.join("ercc_bt2_aligned_sorted.bam"),
     ).await?;
     cleanup_tasks.extend(ercc_bt2_cleanup_tasks);
-    cleanup_receivers.extend(ercc_bt2_cleanup_receivers);
     final_temp_dirs.extend(ercc_bt2_temp_dirs);
 
     // QC with fastp
@@ -7802,10 +7807,9 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         ercc_bt2_out_stream,
     ).await?;
     cleanup_tasks.extend(qc_cleanup_tasks);
-    cleanup_receivers.extend(qc_cleanup_receivers);
 
     // Split for Kallisto and Bowtie2
-    let (kallisto_streams, kallisto_router_handle) = fanout_to_channels(
+    let (kallisto_streams, kallisto_done) = fanout_to_channels(
         qc_fastp_out_stream,
         2,
         "kallisto_split",
@@ -7815,8 +7819,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         .await
         .map_err(|_| PipelineError::StreamDataDropped)?;
 
-    // track router task
-    cleanup_tasks.push(kallisto_router_handle);
 
     let mut kallisto_streams_iter = kallisto_streams.into_iter();
 
@@ -7851,8 +7853,25 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         out_dir.join("host_bt2_aligned_sorted.bam"),
     ).await?;
     cleanup_tasks.extend(host_bt2_cleanup_tasks);
-    cleanup_receivers.extend(host_bt2_cleanup_receivers);
     host_filter_temp_dirs.extend(host_bt2_temp_dirs);
+
+    // HISAT2 forced checkpoint cleanup block
+    // ERCC bt2 fanout is also done by this point in the pipeline
+    for rx in ercc_bt2_cleanup_receivers {
+        rx.await??;
+    }
+
+    for rx in qc_cleanup_receivers {
+        rx.await??;
+    }
+
+    // because the stream is forced to checkpoint by hisat2, we can await the kallisto receiver from the fanout here
+    kallisto_done.await?;
+
+    // Host bt2 fanout is done (its fastq branch fed into hisat2)
+    for rx in host_bt2_cleanup_receivers {
+        rx.await??;
+    }
 
 
     //host filtering hisat2
@@ -7870,13 +7889,15 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     )
         .await?;
     cleanup_tasks.append(&mut host_hisat2_cleanup_tasks);
-    cleanup_receivers.append(&mut host_hisat2_cleanup_receivers);
     host_filter_temp_dirs.extend(hisat_temp_dirs);
 
 
     // If host is no huma, run an additional filter stage using a human reference
     let mut optional_human_bam_write_handle: Option<JoinHandle<Result<()>>> = None;
     let mut optional_human_bam_path: Option<PathBuf> = None;
+
+    let mut hisat2_cleanup_receivers = host_hisat2_cleanup_receivers;
+
 
     let post_filter_stream = if config.args.human_host {
         host_hisat2_out_stream
@@ -7907,8 +7928,11 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             .await?;
 
         cleanup_tasks.extend(human_bt2_cleanup_tasks);
-        cleanup_receivers.extend(human_bt2_cleanup_receivers);
         host_filter_temp_dirs.extend(human_bt2_temp_dirs);
+
+        for rx in human_bt2_cleanup_receivers {
+            rx.await??;
+        }
 
         // Save the BAM write handle and path for later awaiting / insert stats
         optional_human_bam_write_handle = Some(human_bt2_bam_write_handle);
@@ -7936,7 +7960,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             .await?;
 
         cleanup_tasks.append(&mut human_hisat2_cleanup_tasks);
-        cleanup_receivers.append(&mut human_hisat2_cleanup_receivers);
+        hisat2_cleanup_receivers.extend(human_hisat2_cleanup_receivers);
         host_filter_temp_dirs.extend(human_hisat_temp_dirs);
 
         human_hisat2_out_stream
@@ -8074,6 +8098,10 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     },
 )?;
 
+    for rx in hisat2_cleanup_receivers {
+        rx.await??;
+    }
+
     info!("Checkpoint complete. Files: r1:{:?}   r2:{:?}", non_host_r1_path, non_host_r2_path_opt);
 
 
@@ -8146,7 +8174,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     )
         .await?;
     cleanup_tasks.append(&mut m8_cleanup_tasks);
-    cleanup_receivers.append(&mut m8_cleanup_receivers);
+
 
     // ────────────────────────────────────────────────────────────────
     // Sort m8 by read ID before call_hits_m8
@@ -8163,6 +8191,10 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     m8_sorted_start.elapsed()
 );
 
+    for rx in m8_cleanup_receivers {
+        rx.await??;
+    }
+
     let (lineage_map, acc2taxid_map) = taxonomy_handle.await??;
 
     let nt_concurrency = compute_phase_concurrency(
@@ -8176,7 +8208,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     info!("call hits nt concurrency {}", nt_concurrency);
 
     let nt_call_hits_start = Instant::now();
-    let (nt_call_stream, nt_call_summary_stream, mut call_cleanup_tasks, mut call_cleanup_receivers) = call_hits_m8(
+    let (nt_call_stream, nt_call_summary_stream, mut nt_call_cleanup_tasks, mut nt_call_cleanup_receivers) = call_hits_m8(
         config.clone(),
         m8_sorted,                    // ←←← NOW SORTED
         sample_base_buf.clone(),
@@ -8192,8 +8224,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     nt_call_hits_start.elapsed()
 );
 
-    cleanup_tasks.append(&mut call_cleanup_tasks);
-    cleanup_receivers.append(&mut call_cleanup_receivers);
+    cleanup_tasks.append(&mut nt_call_cleanup_tasks);
 
     info!("[run] wrapping NT outputs with monitor_stream");
 
@@ -8212,7 +8243,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     let nt_split_start = Instant::now();
     info!("[run] starting fanout_to_channels for NT call m8 (2 private channels)");
 
-    let (nt_call_rxs, nt_call_router) = fanout_to_channels(
+    let (nt_call_rxs, nt_call_done) = fanout_to_channels(
         nt_call_stream,                    // already the monitored stream from call_hits_m8
         2, // generous buffer for m8 lines
         "nt_call",
@@ -8220,7 +8251,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         StreamDataType::JustBytes
     ).await?;
 
-    cleanup_tasks.push(nt_call_router);    // router returns the correct JoinHandle type
 
     info!(
         "[run] fanout_to_channels(nt_call) ready after {:?} with 2 private channels",
@@ -8247,15 +8277,13 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     let nt_summary_split_start = Instant::now();
     info!("[run] starting fanout_to_channels for NT summary (6 private channels)");
 
-    let (nt_summary_rxs, nt_summary_router) = fanout_to_channels(
+    let (nt_summary_rxs, nt_summary_done_rx) = fanout_to_channels(
         nt_call_summary_stream,
         6,
         "nt_call_summary",
         &config,
         StreamDataType::JustBytes
     ).await?;
-
-    cleanup_tasks.push(nt_summary_router);     // now the correct type
 
     info!(
         "[run] fanout_to_channels(nt_call_summary) ready after {:?} with 6 private channels",
@@ -8420,12 +8448,11 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             "nr".to_string(),
         ).await?;
     cleanup_tasks.append(&mut nr_call_cleanup_tasks);
-    cleanup_receivers.append(&mut nr_call_cleanup_receivers);
 
     let nr_split_start = Instant::now();
     info!("[run] starting fanout_to_channels for NT call m8 (2 private channels)");
 
-    let (nr_call_rxs, nr_call_router) = fanout_to_channels(
+    let (nr_call_rxs, nr_call_done) = fanout_to_channels(
         nr_call_stream,                    // already the monitored stream from call_hits_m8
         2,
         "nr_call",
@@ -8433,7 +8460,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         StreamDataType::JustBytes
     ).await?;
 
-    cleanup_tasks.push(nr_call_router);    // router returns the correct JoinHandle type
 
     info!(
     "[run] fanout_to_channels(nr_call) ready after {:?} with 2 private channels",
@@ -8446,7 +8472,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
 
     let nr_summary_split_start = Instant::now();
     info!("[run] starting fanout_to_channels for NR summary (6 private channels)");
-    let (nr_summary_rxs, nr_summary_router) = fanout_to_channels(
+    let (nr_summary_rxs, nr_summary_done_rx) = fanout_to_channels(
         nr_call_summary_stream,
         6,
         "nr_call_summary",
@@ -8454,7 +8480,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         StreamDataType::JustBytes
     ).await?;
 
-    cleanup_tasks.push(nr_summary_router);     // now the correct type
 
     info!(
      "[run] fanout_to_channels(nr_call_summary) ready after {:?} with 6 private channels",
@@ -8564,7 +8589,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
 
     info!("[run] starting fanout_to_channels for annotated FASTA (2 private channels)");
 
-    let (annotated_rxs, annotated_router) = fanout_to_channels(
+    let (annotated_rxs, annotated_done_rx) = fanout_to_channels(
         ReceiverStream::new(annotated_rx),
         2,
         "initial_annotated",
@@ -8572,13 +8597,12 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         StreamDataType::JustBytes
     ).await?;
 
-    cleanup_tasks.push(annotated_router);
 
     let mut annotated_rxs_iter = annotated_rxs.into_iter();
     let initial_annotated_file_stream = annotated_rxs_iter.next().ok_or(PipelineError::EmptyStream)?;
     let initial_annotated_taxon_stream = annotated_rxs_iter.next().ok_or(PipelineError::EmptyStream)?;
 
-    let (unidentified_rxs, unidentified_router) = fanout_to_channels(
+    let (unidentified_rxs, unidentified_done_rx) = fanout_to_channels(
         ReceiverStream::new(unidentified_rx),
         2,
         "initial_unidentified",
@@ -8586,7 +8610,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         StreamDataType::JustBytes
     ).await?;
 
-    cleanup_tasks.push(unidentified_router);
 
     let mut unidentified_rxs_iter = unidentified_rxs.into_iter();
     let initial_unidentified_file_stream = unidentified_rxs_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -8653,7 +8676,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     ).await?;
 
     cleanup_tasks.extend(post_assembly_cleanup_tasks);
-    cleanup_receivers.extend(post_assembly_cleanup_receivers);
+    // cleanup_receivers.extend(post_assembly_cleanup_receivers);
     temp_files.extend(post_assembly_temp_files);
     final_temp_dirs.push(post_assembly_temp_dir);
 
@@ -8671,6 +8694,10 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         .map_err(|e| anyhow!("generate_assembly_coverage failed: {}", e))?;
     eprintln!("coverage result {:?}", generate_assembly_coverage_result);
 
+
+    for rx in post_assembly_cleanup_receivers {
+        rx.await??;
+    }
 
     let nt_file = config
         .args
@@ -8798,6 +8825,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     let nr_counts = nr_counts?;
 
 
+
     let combined_path = out_dir.join(rename_file_path(
         &sample_base_buf,
         None,
@@ -8923,31 +8951,31 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             ) = nt_res;
 
             let mut cleanup_tasks = nt_cleanup_tasks;
-            let cleanup_receivers = nt_cleanup_receivers;
+            let mut cleanup_receivers = nt_cleanup_receivers;
             let temp_files = nt_temp_files;
 
-            let (nt_m8_rxs, nt_m8_router) = fanout_to_channels(
+            let (nt_m8_rxs, nt_m8_done_rx) = fanout_to_channels(
                 ReceiverStream::new(nt_refined_m8_stream_out),
                 3,
                 "nt_m8",
                 &config,
                 StreamDataType::JustBytes
             ).await?;
-            cleanup_tasks.push(nt_m8_router);
+            cleanup_receivers.push(nt_m8_done_rx);
 
             let mut nt_m8_iter = nt_m8_rxs.into_iter();
             let nt_m8_merge = nt_m8_iter.next().ok_or(PipelineError::EmptyStream)?;
             let nt_m8_map = nt_m8_iter.next().ok_or(PipelineError::EmptyStream)?;
             let nt_m8_viz = nt_m8_iter.next().ok_or(PipelineError::EmptyStream)?;
 
-            let (nt_hitsummary_rxs, nt_hitsummary_router) = fanout_to_channels(
+            let (nt_hitsummary_rxs, nt_hitsummary_done_rx) = fanout_to_channels(
                 ReceiverStream::new(nt_refined_hit_summary_stream_out),
                 3,
                 "nt_hitsummary",
                 &config,
                 StreamDataType::JustBytes
             ).await?;
-            cleanup_tasks.push(nt_hitsummary_router);
+            cleanup_receivers.push(nt_hitsummary_done_rx);
 
             let mut nt_hitsummary_iter = nt_hitsummary_rxs.into_iter();
             let nt_hit_summary_merge = nt_hitsummary_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -8972,6 +9000,10 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         }
     });
 
+    // Both branches of nt_call fanout and nr_call fanout are done
+    nt_call_done.await??;
+    nr_call_done.await??;
+
     let nr_post_handle = tokio::spawn({
         let config = config.clone();
         async move {
@@ -8992,30 +9024,30 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
             ) = nr_res;
 
             let mut cleanup_tasks = nr_cleanup_tasks;
-            let cleanup_receivers = nr_cleanup_receivers;
+            let mut cleanup_receivers = nr_cleanup_receivers;
             let temp_files = nr_temp_files;
 
-            let (nr_m8_rxs, nr_m8_router) = fanout_to_channels(
+            let (nr_m8_rxs, nr_m8_done_rx) = fanout_to_channels(
                 ReceiverStream::new(nr_refined_m8_stream_out),
                 2,
                 "nr_m8",
                 &config,
                 StreamDataType::JustBytes
             ).await?;
-            cleanup_tasks.push(nr_m8_router);
+            cleanup_receivers.push(nr_m8_done_rx);
 
             let mut nr_m8_iter = nr_m8_rxs.into_iter();
             let nr_m8_merge = nr_m8_iter.next().ok_or(PipelineError::EmptyStream)?;
             let nr_m8_map = nr_m8_iter.next().ok_or(PipelineError::EmptyStream)?;
 
-            let (nr_hitsummary_rxs, nr_hitsummary_router) = fanout_to_channels(
+            let (nr_hitsummary_rxs, nr_hitsummary_done_rx) = fanout_to_channels(
                 ReceiverStream::new(nr_refined_hit_summary_stream_out),
                 3,
                 "nr_hitsummary",
                 &config,
                 StreamDataType::JustBytes
             ).await?;
-            cleanup_tasks.push(nr_hitsummary_router);
+            cleanup_receivers.push(nr_hitsummary_done_rx);
 
             let mut nr_hitsummary_iter = nr_hitsummary_rxs.into_iter();
             let nr_hit_summary_merge = nr_hitsummary_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -9045,6 +9077,7 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     let nr_post_res = nr_post_res
         .map_err(|e| PipelineError::Other(anyhow!("NR blast_contigs postprocess task panicked: {e}")))??;
 
+
     let (
         _nt_read_dict,
         nt_refined_counts,
@@ -9061,7 +9094,6 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         nt_temp_files,
     ) = nt_post_res;
     cleanup_tasks.extend(nt_cleanup_tasks);
-    cleanup_receivers.extend(nt_cleanup_receivers);
     temp_files.extend(nt_temp_files);
 
     let (
@@ -9078,8 +9110,23 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         nr_temp_files,
     ) = nr_post_res;
     cleanup_tasks.extend(nr_cleanup_tasks);
-    cleanup_receivers.extend(nr_cleanup_receivers);
     temp_files.extend(nr_temp_files);
+
+    // or is nt_blast_stream done here?
+
+    for rx in nt_cleanup_receivers { rx.await??; }
+    for rx in nr_cleanup_receivers { rx.await??; }
+
+    // 2. Now safe to await the big summary fanout
+    //    (because blast_hit branch has finished)
+    nt_summary_done_rx.await??;
+    nr_summary_done_rx.await??;
+
+    // 3. Now safe to await call_hits_m8 internal fanouts
+    //    (their outputs were consumed by nt_call + nt_call_summary fanouts)
+    for rx in nt_call_cleanup_receivers { rx.await??; }
+    for rx in nr_call_cleanup_receivers { rx.await??; }
+
 
     // ────────────────────────────────────────────────────────────────
     // PRELOAD NR alignments (parallel version)
@@ -9219,14 +9266,14 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
     cleanup_tasks.push(taxid_main_task);
 
 
-    let (taxid_mapped_rxs, taxid_mapped_router) = fanout_to_channels(
+    let (taxid_mapped_rxs, taxid_mapped_done_rx) = fanout_to_channels(
         ReceiverStream::new(taxid_mapped_rx),
         2,
         "taxid_mapped",
         &config,
         StreamDataType::JustBytes
     ).await?;
-    cleanup_tasks.push(taxid_mapped_router);
+    cleanup_receivers.push(taxid_mapped_done_rx);
 
     let mut taxid_mapped_iter = taxid_mapped_rxs.into_iter();
     let taxid_mapped_file   = taxid_mapped_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -9301,28 +9348,28 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
 
     info!("[run] starting fanout_to_channels for initial taxid FASTA (mapped + combined)");
 
-    let (initial_mapped_rxs, initial_mapped_router) = fanout_to_channels(
+    let (initial_mapped_rxs, initial_mapped_done_rx) = fanout_to_channels(
         ReceiverStream::new(initial_taxid_mapped_rx),
         3,
         "initial_taxid_mapped",
         &config,
         StreamDataType::JustBytes
     ).await?;
-    cleanup_tasks.push(initial_mapped_router);
+    cleanup_receivers.push(initial_mapped_done_rx);
 
     let mut initial_mapped_iter = initial_mapped_rxs.into_iter();
     let initial_taxid_mapped_file = initial_mapped_iter.next().ok_or(PipelineError::EmptyStream)?;
     let initial_taxid_mapped_locator = initial_mapped_iter.next().ok_or(PipelineError::EmptyStream)?;
     let initial_taxid_mapped_count = initial_mapped_iter.next().ok_or(PipelineError::EmptyStream)?;
 
-    let (initial_combined_rxs, initial_combined_router) = fanout_to_channels(
+    let (initial_combined_rxs, initial_combined_done_rx) = fanout_to_channels(
         ReceiverStream::new(initial_taxid_combined_rx),
         2,
         "initial_taxid_combined",
         &config,
         StreamDataType::JustBytes
     ).await?;
-    cleanup_tasks.push(initial_combined_router);
+    cleanup_receivers.push(initial_combined_done_rx);
 
     let mut initial_combined_iter = initial_combined_rxs.into_iter();
     let initial_taxid_combined_file = initial_combined_iter.next().ok_or(PipelineError::EmptyStream)?;
@@ -9374,6 +9421,11 @@ pub async fn run(config: Arc<RunConfig>) -> anyhow::Result<(), PipelineError> {
         .await
         .map_err(|e| PipelineError::Other(anyhow!("Experimental generate_taxid_locator failed: {}", e)))?;
     info!("second generate_taxid_locator odone ");
+
+    // Now safe to await the annotated and unidentified fanout tasks
+    annotated_done_rx.await??;
+    unidentified_done_rx.await??;
+
     cleanup_tasks.append(&mut initial_locator_tasks);
     info!("Experimental taxid locator files generated: {:?}", initial_locator_outputs);
 

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -177,169 +177,6 @@ impl AsyncRead for ChannelReader {
     }
 }
 
-/// Fans oiut data piece by peiecve to donstream consumers
-/// NOTE: does NOT give each cocnusmer ALL data. NOT used for "splitting" streams!!
-/// if feeding reads a b c to two consumers
-/// Task A: recv() → gets `a`
-/// Task B: recv() → gets `b`
-/// Task A: recv() → gets `c`
-/// # Arguments
-///
-/// * `input_stream`: An asynchronous stream yielding items of type `T`.
-/// * `num_streams`: Number of output streams to generate.
-/// * `stall_threshold_secs`: Seconds before logging a stall.
-/// * `sleep_duration_ms`: Optional milliseconds to sleep per item (None for no sleep).
-///
-/// # Returns
-/// A `Result` containing a tuple of:
-/// - A vector of `mpsc::Receiver<T>` for downstream processing.
-/// - A `oneshot::Receiver<()>` to await task completion.
-pub async fn t_junction<S>(
-    input: S,
-    n_outputs: usize,
-    base_buffer_size: usize,
-    stall_threshold: u64,
-    stream_sleep_ms: Option<u64>,
-    _backpressure_pause_ms: u64,
-    data_type: StreamDataType,
-    label: String,
-    notify: Option<Arc<Notify>>,
-) -> Result<(Vec<mpsc::Receiver<ParseOutput>>, oneshot::Receiver<Result<(), anyhow::Error>>)>
-where
-    S: Stream<Item = ParseOutput> + Unpin + Send + 'static,
-{
-    if n_outputs == 0 {
-        return Err(anyhow!("No subscribers: cannot process stream in {}", label));
-    }
-
-    let mut system = System::new_all();
-    system.refresh_memory();
-    let mut available_ram = system.available_memory();
-    if available_ram == 0 {
-        available_ram = system.total_memory().max(8_000_000_000) / 4;
-    }
-
-    const MAX_PROCESSES: usize = 4;
-    const RAM_FRACTION: f64 = 0.5;
-    const MIN_BUFFER_PER_STREAM: usize = 10_000;
-    const MAX_BUFFER_PER_STREAM: usize = 2_000_000;
-
-    let record_size = match data_type {
-        StreamDataType::IlluminaFastq => 1_000, // ~1KB per FASTQ record
-        StreamDataType::OntFastq => 10_000,     // ~10KB per ONT read
-        StreamDataType::JustBytes => 500,       // ~500B for SAM/BAM/VCF
-    };
-
-    let min_buffer_size = MIN_BUFFER_PER_STREAM * n_outputs.max(1);
-    let max_buffer_size = if available_ram > 0 {
-        let calculated = ((available_ram as f64 * RAM_FRACTION / MAX_PROCESSES as f64) / record_size as f64) as usize;
-        calculated.max(min_buffer_size)
-    } else {
-        warn!("Failed to detect available RAM in {}, using fallback", label);
-        (base_buffer_size * n_outputs.max(1) * 2).max(min_buffer_size)
-    };
-    let buffer_size = (base_buffer_size * n_outputs.max(1))
-        .clamp(min_buffer_size, max_buffer_size.min(MAX_BUFFER_PER_STREAM));
-
-    let (done_tx, done_rx) = oneshot::channel::<Result<(), anyhow::Error>>();
-    let mut output_txs: Vec<(usize, mpsc::Sender<ParseOutput>)> = Vec::with_capacity(n_outputs);
-    let mut output_rxs = Vec::with_capacity(n_outputs);
-
-    for i in 0..n_outputs {
-        let (tx, rx) = mpsc::channel(buffer_size);
-        output_txs.push((i, tx));
-        output_rxs.push(rx);
-    }
-
-    tokio::spawn(async move {
-        let mut input = Box::pin(input);
-        let mut item_count = 0;
-        let mut last_progress_time = Instant::now();
-        let mut dropped_receivers = Vec::new();
-
-        while let Some(item) = input.next().await {
-            item_count += 1;
-            let mut active_txs = Vec::new();
-            let mut lowest_capacity_ratio = 1.0f64; // tracks the worst receiver
-
-            for (i, tx) in output_txs.into_iter() {
-                let capacity_ratio = tx.capacity() as f64 / buffer_size as f64;
-                lowest_capacity_ratio = lowest_capacity_ratio.min(capacity_ratio);
-
-                match tx.try_send(item.clone()) {
-                    Ok(()) => active_txs.push((i, tx)),
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        if tx.send(item.clone()).await.is_err() {
-                            error!("{}: Receiver {} dropped at item {}", label, i, item_count);
-                            dropped_receivers.push(i);
-                        } else {
-                            active_txs.push((i, tx));
-                        }
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        error!("{}: Receiver {} dropped at item {}", label, i, item_count);
-                        dropped_receivers.push(i);
-                    }
-                }
-            }
-
-            output_txs = active_txs;
-            if output_txs.is_empty() {
-                error!("{}: All receivers dropped at item {}. Dropped: {:?}", label, item_count, dropped_receivers);
-                let _ = done_tx.send(Err(anyhow!("All receivers dropped at item {}", item_count)));
-                return;
-            }
-
-            // Per-item backpressure: only slow down when the SLOWEST receiver is truly full.
-            if lowest_capacity_ratio < 0.05 {
-                if item_count % 5000 == 0 {
-                    debug!(
-                        "{}: Heavy backpressure detected (lowest capacity {:.1}%). Sleep 10ms.",
-                        label, lowest_capacity_ratio * 100.0
-                    );
-                }
-                sleep(Duration::from_millis(10)).await;
-            } else if lowest_capacity_ratio < 0.20 {
-                tokio::task::yield_now().await;
-            }
-
-            if item_count % stall_threshold == 0 {
-                if let Some(sleep_ms) = stream_sleep_ms {
-                    debug!("{}: Periodic stall check sleep {}ms at item {}", label, sleep_ms, item_count);
-                    sleep(Duration::from_millis(sleep_ms)).await;
-                }
-            }
-
-            if last_progress_time.elapsed() > Duration::from_secs(60) {
-                debug!("{}: Progress update — processed {} items", label, item_count);
-                last_progress_time = Instant::now();
-            }
-        }
-
-        for (i, _) in output_txs {
-            debug!("{}: Closed sender for receiver {} after {} items", label, i, item_count);
-        }
-
-        if let Some(n) = notify {
-            n.notify_waiters();
-        }
-
-        if dropped_receivers.is_empty() {
-            let _ = done_tx.send(Ok(()));
-        } else {
-            let _ = done_tx.send(Err(anyhow!(
-                "{}: {} receivers dropped: {:?}",
-                label,
-                dropped_receivers.len(),
-                dropped_receivers
-            )));
-        }
-    });
-
-    Ok((output_rxs, done_rx))
-}
-
-
 /// Returns the binary + arguments to use, optionally wrapped with numactl.
 ///
 /// This is the single source of truth for numactl policy.
@@ -679,12 +516,6 @@ pub async fn spawn_cmd(
     Ok((child, stderr_task))
 }
 
-/// Helper: which tools should get numactl on large Linux nodes
-fn should_use_numactl(config: &RunConfig, cmd_tag: &str) -> bool {
-    cfg!(target_os = "linux")
-        && config.max_cores >= 64
-        && (cmd_tag == MMSEQS_TAG || cmd_tag == SPADES_TAG || cmd_tag == DIAMOND_TAG)
-}
 
 /// Parse the output of a stream, either Fastq or simple bytes.
 ///
@@ -1438,190 +1269,6 @@ pub async fn deinterleave_fastq_stream_to_fifos(
 }
 
 
-pub async fn deinterleave_fastq_stream_to_process_sub<S>(
-    config: Arc<RunConfig>,
-    input_stream: S,
-    sample_id: &str,
-    paired: bool,
-) -> Result<(
-    String,                                // r1_fd_str
-    Option<String>,                       // r2_fd_str
-    JoinHandle<Result<(), anyhow::Error>>, // combined_handle
-    Option<JoinHandle<Result<(), anyhow::Error>>>, // unused (kept for compatibility)
-    Arc<Notify>,                          // writers_ready
-    PathBuf,                              // r1_fifo
-    Option<PathBuf>,                      // r2_fifo
-)>
-where
-    S: Stream<Item = ParseOutput> + Unpin + Send + 'static,
-{
-    // Split stream into two (R1 and R2 for paired, R1 only for single-end)
-    let num_outputs = if paired { 2 } else { 1 }; // Fix: Only 1 or 2 outputs
-    let (output_rxs, done_rx) = t_junction(
-        input_stream,
-        num_outputs,
-        config.base_buffer_size * 10, // Large buffer for 1.5TB RAM
-        config.args.stall_threshold,
-        Some(10), // Throttle for large inputs
-        100,      // Backpressure pause
-        StreamDataType::IlluminaFastq,
-        format!("deinterleave_process_sub_{}", sample_id),
-        None,
-    ).await?;
-
-    let mut rxs = output_rxs.into_iter();
-    let r1_write_rx = rxs.next().ok_or(PipelineError::EmptyStream)?;
-    let r2_write_rx = if paired { rxs.next() } else { None };
-
-    let writers_ready = Arc::new(Notify::new());
-
-    // Create temp FIFO for R1 (use RAM-based temp dir for speed)
-    let r1_fifo = config.ram_temp_dir.join(format!("{}_r1_{}.fifo", sample_id, Uuid::new_v4()));
-    create_fifo(&r1_fifo).await.map_err(|e| anyhow!("Failed to create R1 FIFO: {}", e))?;
-
-    // Spawn cat process for R1, reading from FIFO
-    let mut r1_child = Command::new("cat")
-        .arg(&r1_fifo)
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| anyhow!("Failed to spawn cat for R1: {}", e))?;
-    let r1_child_stdout = r1_child.stdout.take().ok_or(anyhow!("No stdout for R1 cat"))?;
-    let r1_fd = r1_child_stdout.as_raw_fd();
-    let r1_fd_str = format!("/dev/fd/{}", r1_fd);
-    debug!("Created R1 file descriptor: {}", r1_fd_str);
-
-    // Hold stdout to prevent premature closure
-    let r1_child_stdout = Arc::new(r1_child_stdout); // Keep alive
-    let r1_cat_handle: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
-        r1_child.wait().await.map_err(|e| anyhow!("R1 cat process failed: {}", e))?;
-        debug!("R1 cat process completed");
-        Ok(())
-    });
-
-    // Spawn R1 writer
-    let r1_fifo_clone = r1_fifo.clone(); // Clone for use in closure
-    let writers_ready_clone = writers_ready.clone();
-    let r1_child_stdout_clone = r1_child_stdout.clone(); // Keep stdout alive
-    let r1_handle = tokio::spawn(async move {
-        debug!("Opened R1 process substitution for writing");
-        writers_ready_clone.notify_one(); // Signal ready
-        let mut expect_r1 = true;
-        let mut input = ReceiverStream::new(r1_write_rx);
-        let mut r1_writer = BufWriter::with_capacity(16_777_216, TokioFile::create(&r1_fifo_clone).await?);
-        let mut bytes_written = 0;
-
-        while let Some(item) = input.next().await {
-            match item {
-                ParseOutput::Fastq(_) => {
-                    if paired {
-                        if expect_r1 {
-                            let bytes = item.to_bytes()?;
-                            r1_writer.write_all(&bytes).await?;
-                            bytes_written += bytes.len();
-                            expect_r1 = false;
-                        } else {
-                            // Skip R2 records for R1 stream
-                            expect_r1 = true;
-                            continue;
-                        }
-                    } else {
-                        let bytes = item.to_bytes()?;
-                        r1_writer.write_all(&bytes).await?;
-                        bytes_written += bytes.len();
-                    }
-                }
-                _ => return Err(anyhow!("Non-FASTQ in R1 stream: {:?}", item)),
-            }
-        }
-        r1_writer.flush().await?;
-        if paired && !expect_r1 {
-            return Err(anyhow!("Incomplete paired-end FASTQ: missing R2"));
-        }
-        debug!("Finished writing {} bytes to R1 process substitution", bytes_written);
-        drop(r1_child_stdout_clone); // Explicitly drop stdout after writing
-        done_rx.await??; // Check for stream drops
-        Ok(())
-    });
-
-    // R2 handling for paired-end
-    let (r2_fd_str, r2_handle, r2_cat_handle, r2_fifo) = if paired {
-        let r2_fifo = config.ram_temp_dir.join(format!("{}_r2_{}.fifo", sample_id, Uuid::new_v4()));
-        create_fifo(&r2_fifo).await.map_err(|e| anyhow!("Failed to create R2 FIFO: {}", e))?;
-
-        let r2_fifo_clone = r2_fifo.clone(); // Clone for use in closure
-        let mut r2_child = Command::new("cat")
-            .arg(&r2_fifo)
-            .stdout(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| anyhow!("Failed to spawn cat for R2: {}", e))?;
-        let r2_child_stdout = r2_child.stdout.take().ok_or(anyhow!("No stdout for R2 cat"))?;
-        let r2_fd = r2_child_stdout.as_raw_fd();
-        let r2_fd_str = format!("/dev/fd/{}", r2_fd);
-        debug!("Created R2 file descriptor: {}", r2_fd_str);
-
-        let r2_child_stdout = Arc::new(r2_child_stdout); // Keep alive
-        let r2_cat_handle: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
-            r2_child.wait().await.map_err(|e| anyhow!("R2 cat process failed: {}", e))?;
-            debug!("R2 cat process completed");
-            Ok(())
-        });
-
-        let writers_ready_clone = writers_ready.clone();
-        let r2_child_stdout_clone = r2_child_stdout.clone(); // Keep stdout alive
-        let r2_handle = tokio::spawn(async move {
-            debug!("Opened R2 process substitution for writing");
-            writers_ready_clone.notify_one(); // Signal ready
-            let mut input = ReceiverStream::new(r2_write_rx.unwrap());
-            let mut r2_writer = BufWriter::with_capacity(16_777_216, TokioFile::create(&r2_fifo_clone).await?);
-            let mut bytes_written = 0;
-            let mut expect_r2 = false;
-
-            while let Some(item) = input.next().await {
-                match item {
-                    ParseOutput::Fastq(_) => {
-                        if expect_r2 {
-                            let bytes = item.to_bytes()?;
-                            r2_writer.write_all(&bytes).await?;
-                            bytes_written += bytes.len();
-                            expect_r2 = false;
-                        } else {
-                            // Skip R1 records for R2 stream
-                            expect_r2 = true;
-                            continue;
-                        }
-                    }
-                    _ => return Err(anyhow!("Non-FASTQ in R2 stream: {:?}", item)),
-                }
-            }
-            r2_writer.flush().await?;
-            if expect_r2 {
-                return Err(anyhow!("Incomplete paired-end FASTQ: missing R1"));
-            }
-            debug!("Finished writing {} bytes to R2 process substitution", bytes_written);
-            drop(r2_child_stdout_clone); // Explicitly drop stdout after writing
-            Ok(())
-        });
-
-        (Some(r2_fd_str), Some(r2_handle), Some(r2_cat_handle), Some(r2_fifo))
-    } else {
-        (None, None, None, None)
-    };
-
-    // Combine handles for R1 and R2 (if paired)
-    let combined_handle = tokio::spawn(async move {
-        r1_handle.await??;
-        if let Some(r2) = r2_handle {
-            r2.await??;
-        }
-        r1_cat_handle.await??;
-        if let Some(r2_cat) = r2_cat_handle {
-            r2_cat.await??;
-        }
-        Ok(())
-    });
-
-    Ok((r1_fd_str, r2_fd_str, combined_handle, None, writers_ready, r1_fifo, r2_fifo))
-}
 
 pub async fn interleave_fastq_streams(
     r1_rx: mpsc::Receiver<ParseOutput>,
@@ -1911,7 +1558,7 @@ pub fn monitor_stream(
 }
 
 
-/// Guarantees: zero data drops, respects t_junction backpressure, cleanup_receivers untouched.
+/// Guarantees: zero data drops,  cleanup_receivers untouched.
 ///
 /// Speed improvements
 /// - reuses the input batch buffer allocation instead of `std::mem::take`
@@ -2369,47 +2016,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_child_output_lines() -> Result<()> {
+    async fn test_fanout_to_channels_zero_branches() -> Result<()> {
         let config = create_test_run_config();
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg("printf 'alpha\\n\\n beta\\n gamma\\n'");
-        let mut child = cmd.stdout(std::process::Stdio::piped()).spawn()?;
-        let rx = parse_child_output(&mut child, ChildStream::Stdout, ParseMode::Lines, &config).await?;
-        let mut stream = ReceiverStream::new(rx);
-        let mut got = Vec::new();
-        while let Some(ParseOutput::Bytes(bytes)) = stream.next().await {
-            got.push(String::from_utf8(bytes.to_vec())?);
-        }
-        assert_eq!(got, vec!["alpha", " beta", " gamma"]);
-        Ok(())
-    }
+        let (up_tx, up_rx) = mpsc::channel(8);
+        let upstream = ReceiverStream::new(up_rx);
+        drop(up_tx);
 
-    #[tokio::test]
-    async fn test_t_junction_zero_streams() -> Result<()> {
-        let stream = fastx_generator(10, 143, 35.0, 3.0).map(ParseOutput::Fastq);
-        let result = t_junction(
-            stream,
+        let (receivers, _router) = fanout_to_channels(
+            upstream,
             0,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_zero",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_zero_streams".to_string(),
-            None,
-        )
-            .await;
-        assert!(result.is_err());
-        let error = result.unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "No subscribers: cannot process stream in test_t_junction_zero_streams"
-        );
+        ).await?;
+        assert_eq!(receivers.len(), 0);
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_two_records() -> Result<()> {
+    async fn test_fanout_to_channels_two_records() -> Result<()> {
+        let config = create_test_run_config();
         let records = vec![
             ParseOutput::Fastq(SequenceRecord::Fastq {
                 id: "read1".to_string(),
@@ -2424,29 +2050,33 @@ mod tests {
                 qual: Bytes::from_static(b"HHHH"),
             }),
         ];
-        let stream = tokio_stream::iter(records);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let (up_tx, up_rx) = mpsc::channel(8);
+        for r in records {
+            up_tx.send(r).await.unwrap();
+        }
+        drop(up_tx);
+        let upstream = ReceiverStream::new(up_rx);
+
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             2,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_two_records",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_two_records".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let mut output1 = ReceiverStream::new(outputs.pop().unwrap());
         let mut output2 = ReceiverStream::new(outputs.pop().unwrap());
         let mut records1 = Vec::new();
         let mut records2 = Vec::new();
+
         while let Some(record) = output1.next().await {
             records1.push(record);
         }
         while let Some(record) = output2.next().await {
             records2.push(record);
         }
+
         assert_eq!(records1.len(), 2);
         assert_eq!(records2.len(), 2);
         if let ParseOutput::Fastq(rec) = &records1[0] {
@@ -2455,300 +2085,230 @@ mod tests {
         if let ParseOutput::Fastq(rec) = &records2[0] {
             assert_eq!(rec.id(), "read1");
         }
-        done_rx.await??;
+        router.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_long_stream() -> Result<()> {
-        let stream = fastx_generator(10_000, 143, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+    async fn test_fanout_to_channels_long_stream() -> Result<()> {
+        let config = create_test_run_config();
+        let num_records = 10_000;
+        let (up_tx, up_rx) = mpsc::channel(100);
+        let gen_handle = task::spawn(async move {
+            let mut gen = fastx_generator(num_records, 143, 35.0, 3.0);
+            while let Some(rec) = gen.next().await {
+                up_tx.send(ParseOutput::Fastq(rec)).await.unwrap();
+            }
+        });
+
+        let upstream = ReceiverStream::new(up_rx);
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             2,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_long_stream",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_long_stream".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let mut output1 = ReceiverStream::new(outputs.pop().unwrap());
         let mut output2 = ReceiverStream::new(outputs.pop().unwrap());
-        let mut records1 = Vec::new();
-        let mut records2 = Vec::new();
-        while let Some(record) = output1.next().await {
-            records1.push(record);
-        }
-        while let Some(record) = output2.next().await {
-            records2.push(record);
-        }
-        assert_eq!(records1.len(), 10_000);
-        assert_eq!(records2.len(), 10_000);
-        done_rx.await??;
+        let mut count1 = 0;
+        let mut count2 = 0;
+
+        let h1 = task::spawn(async move {
+            while let Some(_) = output1.next().await {
+                count1 += 1;
+            }
+            count1
+        });
+        let h2 = task::spawn(async move {
+            while let Some(_) = output2.next().await {
+                count2 += 1;
+            }
+            count2
+        });
+
+        let c1 = h1.await?;
+        let c2 = h2.await?;
+        assert_eq!(c1, num_records);
+        assert_eq!(c2, num_records);
+        router.await??;
+        gen_handle.await?;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_ten_thousand_records_ten_streams() -> Result<()> {
-        let stream = fastx_generator(10_000, 143, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (outputs, done_rx) = t_junction(
-            stream,
-            10,
-            50_000,
-            10_000,
-            Some(0),
-            50,
-            StreamDataType::IlluminaFastq,
-            "test_t_junction_ten_streams".to_string(),
-            None,
-        )
-            .await?;
-        let mut records = vec![Vec::new(); outputs.len()];
-        let mut handles = Vec::new();
+    async fn test_fanout_to_channels_ten_thousand_records_ten_branches() -> Result<()> {
+        let config = create_test_run_config();
+        let num_records = 10_000;
+        let num_branches = 10;
+        let (up_tx, up_rx) = mpsc::channel(100);
+        task::spawn(async move {
+            let mut gen = fastx_generator(num_records, 143, 35.0, 3.0);
+            while let Some(rec) = gen.next().await {
+                up_tx.send(ParseOutput::Fastq(rec)).await.unwrap();
+            }
+        });
 
-        for (i, rx) in outputs.into_iter().enumerate() {
+        let upstream = ReceiverStream::new(up_rx);
+        let (outputs, router) = fanout_to_channels(
+            upstream,
+            num_branches,
+            "test_fanout_ten_branches",
+            &config,
+            StreamDataType::IlluminaFastq,
+        ).await?;
+
+        let mut handles = Vec::new();
+        for rx in outputs {
             let handle = task::spawn(async move {
                 let mut stream = ReceiverStream::new(rx);
-                let mut local_records = Vec::new();
-                while let Some(record) = stream.next().await {
-                    local_records.push(record);
+                let mut count = 0;
+                while let Some(_) = stream.next().await {
+                    count += 1;
                 }
-                Ok::<_, anyhow::Error>(local_records)
+                count
             });
-            handles.push((i, handle));
+            handles.push(handle);
         }
 
-        for (i, handle) in handles {
-            let local_records = handle.await??;
-            records[i] = local_records;
+        for handle in handles {
+            let count = handle.await?;
+            assert_eq!(count, num_records);
         }
-
-        for record_set in &records {
-            assert_eq!(record_set.len(), 10_000);
-        }
-        done_rx.await??;
+        router.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_empty_stream() -> Result<()> {
-        let stream = fastx_generator(0, 50, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (outputs, done_rx) = t_junction(
-            stream,
+    async fn test_fanout_to_channels_empty_stream() -> Result<()> {
+        let config = create_test_run_config();
+        let (_up_tx, up_rx) = mpsc::channel::<ParseOutput>(8);
+        let upstream = ReceiverStream::new(up_rx);
+
+        let (outputs, router) = fanout_to_channels(
+            upstream,
             2,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_empty",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_empty_stream".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         for rx in outputs {
             let mut stream = ReceiverStream::new(rx);
-            assert!(stream.next().await.is_none(), "Empty stream should yield no items");
+            assert!(stream.next().await.is_none());
         }
-        done_rx.await??;
+        router.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_single_record() -> Result<()> {
-        let stream = fastx_generator(1, 50, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (outputs, done_rx) = t_junction(
-            stream,
+    async fn test_fanout_to_channels_single_record() -> Result<()> {
+        let config = create_test_run_config();
+        let (up_tx, up_rx) = mpsc::channel(8);
+        task::spawn(async move {
+            let mut gen = fastx_generator(1, 50, 35.0, 3.0);
+            if let Some(rec) = gen.next().await {
+                up_tx.send(ParseOutput::Fastq(rec)).await.unwrap();
+            }
+        });
+
+        let upstream = ReceiverStream::new(up_rx);
+        let (outputs, router) = fanout_to_channels(
+            upstream,
             2,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_single_record",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_single_record".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let mut handles = Vec::new();
         for rx in outputs {
             handles.push(task::spawn(async move {
-                let mut records = Vec::new();
+                let mut count = 0;
                 let mut stream = ReceiverStream::new(rx);
-                while let Some(record) = stream.next().await {
-                    records.push(record);
+                while let Some(_) = stream.next().await {
+                    count += 1;
                 }
-                Ok::<_, anyhow::Error>(records)
+                count
             }));
         }
-        let all_records = time::timeout(Duration::from_secs(10), async {
-            let mut all_records = Vec::new();
-            for handle in handles {
-                let records = handle.await??;
-                all_records.push(records);
-            }
-            Ok::<_, anyhow::Error>(all_records)
-        })
-            .await??;
-        for records in &all_records {
-            assert_eq!(records.len(), 1, "Should have one record");
+
+        for handle in handles {
+            let count = handle.await?;
+            assert_eq!(count, 1);
         }
-        done_rx.await??;
+        router.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_junction_slow_consumer() -> Result<()> {
-        let stream = fastx_generator(1_000, 50, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (outputs, done_rx) = t_junction(
-            stream,
+    async fn test_fanout_to_channels_slow_consumer() -> Result<()> {
+        let config = create_test_run_config();
+        let num_records = 100; // reduced for speed
+        let (up_tx, up_rx) = mpsc::channel(10);
+        task::spawn(async move {
+            let mut gen = fastx_generator(num_records, 50, 35.0, 3.0);
+            while let Some(rec) = gen.next().await {
+                up_tx.send(ParseOutput::Fastq(rec)).await.unwrap();
+            }
+        });
+
+        let upstream = ReceiverStream::new(up_rx);
+        let (outputs, router) = fanout_to_channels(
+            upstream,
             2,
-            500,
-            10,
-            Some(100),
-            50,
+            "test_fanout_slow_consumer",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_slow_consumer".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let mut handles = Vec::new();
         for (i, rx) in outputs.into_iter().enumerate() {
             let handle = task::spawn(async move {
-                let mut records = Vec::new();
+                let mut count = 0;
                 let mut stream = ReceiverStream::new(rx);
-                let consumer_id = i;
-                while let Some(record) = stream.next().await {
-                    records.push(record);
-                    if consumer_id == 1 {
-                        sleep(Duration::from_millis(5)).await; // Simulate slow consumer
+                while let Some(_) = stream.next().await {
+                    count += 1;
+                    if i == 1 {
+                        sleep(Duration::from_millis(10)).await;
                     }
                 }
-                debug!("Consumer {} collected {} records", consumer_id, records.len());
-                Ok::<_, anyhow::Error>(records)
+                count
             });
             handles.push(handle);
         }
-        let _ = time::timeout(Duration::from_secs(120), async {
-            let mut all_records = Vec::with_capacity(2);
-            for (i, handle) in handles.into_iter().enumerate() {
-                let records = handle.await??;
-                debug!("Task {} returned {} records", i, records.len());
-                all_records.push(records);
-            }
-            assert_eq!(all_records.len(), 2, "Expected exactly 2 consumer outputs");
-            assert_eq!(
-                all_records[0].len(),
-                1_000,
-                "Consumer 0 should have all 1000 records, got {}",
-                all_records[0].len()
-            );
-            assert_eq!(
-                all_records[1].len(),
-                1_000,
-                "Consumer 1 should have all 1000 records, got {}",
-                all_records[1].len()
-            );
-            Ok::<_, anyhow::Error>(all_records)
-        })
-            .await
-            .map_err(|_| anyhow!("Test timed out after 120 seconds"))??;
-        done_rx.await??;
+
+        for handle in handles {
+            let count = handle.await?;
+            assert_eq!(count, num_records);
+        }
+        router.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_t_million_records_ten_streams() -> Result<()> {
-        let num_records = 1_000_000;
-        let stream = fastx_generator(num_records, 143, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (outputs, done_rx) = t_junction(
-            stream,
-            2,
-            50_000,
-            10_000,
-            Some(1),
-            50,
-            StreamDataType::IlluminaFastq,
-            "test_t_junction_million_records_ten_streams".to_string(),
-            None,
-        )
-            .await?;
-
-        let mut handles = Vec::new();
-        for rx in outputs {
-            let handle = task::spawn(async move {
-                let mut records = Vec::new();
-                let mut stream = ReceiverStream::new(rx);
-                while let Some(record) = stream.next().await {
-                    records.push(record);
-                }
-                Ok::<_, anyhow::Error>(records)
-            });
-            handles.push(handle);
-        }
-        let all_records = time::timeout(Duration::from_secs(60), async {
-            let mut all_records = Vec::new();
-            for handle in handles {
-                let records = handle.await??;
-                all_records.push(records);
-            }
-            Ok::<_, anyhow::Error>(all_records)
-        })
-            .await??;
-
-        for (i, records) in all_records.iter().enumerate() {
-            assert_eq!(
-                records.len(),
-                num_records,
-                "Output {} should have {} records",
-                i,
-                num_records
-            );
-        }
-
-        for i in 0..num_records {
-            if let (ParseOutput::Fastq(rec0), ParseOutput::Fastq(rec1)) = (&all_records[0][i], &all_records[1][i]) {
-                assert_eq!(
-                    rec0.id(),
-                    rec1.id(),
-                    "Record {} IDs should match",
-                    i
-                );
-                assert_eq!(
-                    rec0.seq(),
-                    rec1.seq(),
-                    "Record {} sequences should match",
-                    i
-                );
-                assert_eq!(
-                    rec0.qual(),
-                    rec1.qual(),
-                    "Record {} quality scores should match",
-                    i
-                );
-            }
-        }
-
-        done_rx.await??;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_stream_to_cmd_valid() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_valid() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(100, 50, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_valid",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_t_junction_stream_to_cmd_valid".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -2766,27 +2326,33 @@ mod tests {
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
         assert!(!output.is_empty(), "Output should contain data");
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_valid_cat() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_valid_cat() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(2, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_valid_cat",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_valid_cat".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -2804,7 +2370,7 @@ mod tests {
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
         assert!(!output.is_empty(), "Output should contain FASTQ data");
         let output_str = String::from_utf8_lossy(&output);
         assert!(output_str.contains("@read1"), "Output should contain first read ID");
@@ -2813,21 +2379,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_valid_parseoutput() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_valid_parseoutput() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(2, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_valid_parse_output",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_valid_parse_output".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
+
         let rx = outputs.pop().unwrap();
         let (tx, rx_parse) = mpsc::channel(100);
         tokio::spawn(async move {
@@ -2856,7 +2428,7 @@ mod tests {
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
         assert!(!output.is_empty(), "Output should contain FASTQ data");
         let output_str = String::from_utf8_lossy(&output);
         assert!(output_str.contains("@read1"), "Output should contain first read ID");
@@ -2865,21 +2437,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_invalid_command() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_invalid_command() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(2, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, _done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, _router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_invalid_cmd",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_invalid_cmd".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
         let result = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -2900,21 +2477,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_empty_stream() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_empty_stream() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(0, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_empty_stream",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_empty_stream".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -2932,28 +2514,33 @@ mod tests {
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
         assert!(output.is_empty(), "Output should be empty for empty stream");
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_large_stream() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_large_stream() -> Result<()> {
         let config = create_test_run_config();
         let num_records = 10_000;
         let stream = fastx_generator(num_records, 50, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_large_stream",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_large_stream".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -2971,7 +2558,7 @@ mod tests {
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
 
         let output_str = String::from_utf8_lossy(&output);
         let mut lines = output_str.lines().peekable();
@@ -3000,21 +2587,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_premature_exit() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_premature_exit() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(10, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_premature_exit",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_premature_exit".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -3031,8 +2623,8 @@ mod tests {
         };
         let mut output = Vec::new();
         tokio::io::copy(&mut stdout, &mut output).await?;
-        task.await??; // Task may error due to BrokenPipe, which is expected for "head -n 1"
-        done_rx.await??;
+        task.await??;
+        router.await??;
         let output_str = String::from_utf8_lossy(&output);
         assert!(output_str.contains("@read1"), "Output should contain first read ID");
         assert!(!output_str.contains("@read2"), "Output should not contain second read ID");
@@ -3040,21 +2632,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_to_cmd_resource_cleanup() -> Result<()> {
+    async fn test_fanout_stream_to_cmd_resource_cleanup() -> Result<()> {
         let config = create_test_run_config();
         let stream = fastx_generator(5, 10, 35.0, 3.0).map(ParseOutput::Fastq);
-        let (mut outputs, done_rx) = t_junction(
-            stream,
+        let upstream = ReceiverStream::new({
+            let (tx, rx) = mpsc::channel(100);
+            tokio::spawn(async move {
+                let mut stream = Box::pin(stream);
+                while let Some(item) = stream.next().await {
+                    let _ = tx.send(item).await;
+                }
+            });
+            rx
+        });
+        let (mut outputs, router) = fanout_to_channels(
+            upstream,
             1,
-            50_000,
-            10_000,
-            Some(1),
-            50,
+            "test_fanout_stream_to_cmd_resource_cleanup",
+            &config,
             StreamDataType::IlluminaFastq,
-            "test_stream_to_cmd_resource_cleanup".to_string(),
-            None,
-        )
-            .await?;
+        ).await?;
         let (child, task, _err_task) = stream_to_cmd(
             config,
             outputs.pop().unwrap(),
@@ -3066,7 +2663,7 @@ mod tests {
         )
             .await?;
         task.await??;
-        done_rx.await??;
+        router.await??;
         let stdin_closed = {
             let guard = child.lock().await;
             guard.stdin.is_none()
@@ -3074,6 +2671,23 @@ mod tests {
         assert!(stdin_closed, "Stdin should be closed");
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_parse_child_output_lines() -> Result<()> {
+        let config = create_test_run_config();
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("printf 'alpha\\n\\n beta\\n gamma\\n'");
+        let mut child = cmd.stdout(std::process::Stdio::piped()).spawn()?;
+        let rx = parse_child_output(&mut child, ChildStream::Stdout, ParseMode::Lines, &config).await?;
+        let mut stream = ReceiverStream::new(rx);
+        let mut got = Vec::new();
+        while let Some(ParseOutput::Bytes(bytes)) = stream.next().await {
+            got.push(String::from_utf8(bytes.to_vec())?);
+        }
+        assert_eq!(got, vec!["alpha", " beta", " gamma"]);
+        Ok(())
+    }
+
 
     #[tokio::test]
     async fn test_parse_child_output_fastq() -> Result<()> {

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -2061,18 +2061,31 @@ mod tests {
     #[tokio::test]
     async fn test_fanout_to_channels_zero_branches() -> Result<()> {
         let config = create_test_run_config();
-        let (up_tx, up_rx) = mpsc::channel(8);
-        let upstream = ReceiverStream::new(up_rx);
-        drop(up_tx);
 
-        let (receivers, _router) = fanout_to_channels(
+        // Explicitly create and drop the sender so the upstream is closed
+        let (up_tx, up_rx) = mpsc::channel::<ParseOutput>(8);
+        drop(up_tx);
+        let upstream = ReceiverStream::new(up_rx);
+
+        let result = fanout_to_channels(
             upstream,
             0,
             "test_fanout_zero",
             &config,
             StreamDataType::IlluminaFastq,
-        ).await?;
-        assert_eq!(receivers.len(), 0);
+        )
+            .await;
+
+        // We expect an error for 0 branches — this is the correct/safe behavior
+        assert!(result.is_err());
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("0 branches"),
+                "Expected error message about 0 branches, got: {}",
+                msg
+            );
+        }
         Ok(())
     }
 
@@ -2226,22 +2239,33 @@ mod tests {
     #[tokio::test]
     async fn test_fanout_to_channels_empty_stream() -> Result<()> {
         let config = create_test_run_config();
-        let (_up_tx, up_rx) = mpsc::channel::<ParseOutput>(8);
+
+        // Create channel and immediately drop the sender so upstream is empty/closed
+        let (up_tx, up_rx) = mpsc::channel::<ParseOutput>(8);
+        drop(up_tx);
         let upstream = ReceiverStream::new(up_rx);
 
-        let (outputs, router) = fanout_to_channels(
+        let (outputs, fanout_done) = fanout_to_channels(
             upstream,
             2,
             "test_fanout_empty",
             &config,
             StreamDataType::IlluminaFastq,
-        ).await?;
+        )
+            .await?;
 
+        // All branches should immediately see EOF
         for rx in outputs {
             let mut stream = ReceiverStream::new(rx);
-            assert!(stream.next().await.is_none());
+            assert!(
+                stream.next().await.is_none(),
+                "Expected None (EOF) from branch receiver on empty upstream"
+            );
         }
-        router.await??;
+
+        // The fanout task should complete cleanly
+        fanout_done.await??;
+
         Ok(())
     }
 

--- a/src/utils/streams.rs
+++ b/src/utils/streams.rs
@@ -1664,57 +1664,100 @@ where
     ReceiverStream::new(rx)
 }
 
-/// Router that reads the upstream ONCE and fans it out to N private channels.
-/// Guarantees immediate draining + instant EOF propagation. No silent drops.
-/// Router that reads the upstream ONCE and fans it out to N private channels.
-/// Guarantees immediate draining + instant EOF propagation. No silent drops.
+/// Broadcasts every item from `upstream` to **all** `n_branches` downstream channels.
+///
+/// Never silently drops data.
+/// Every branch receives every item (or we error loudly).
+/// Every branch sees clean EOF when upstream ends (including the 0-item case).
 pub async fn fanout_to_channels(
     mut upstream: ReceiverStream<ParseOutput>,
     n_branches: usize,
     label: &str,
     config: &RunConfig,
     data_type: StreamDataType,
-) -> Result<(Vec<mpsc::Receiver<ParseOutput>>, JoinHandle<anyhow::Result<(), anyhow::Error>>), PipelineError> {
+) -> Result<(Vec<mpsc::Receiver<ParseOutput>>, oneshot::Receiver<Result<(), anyhow::Error>>), PipelineError> {
+    if n_branches == 0 {
+        return Err(PipelineError::Other(anyhow!("fanout_to_channels called with 0 branches in {}", label)));
+    }
 
-    let buffer_per_branch = crate::utils::system::compute_buffer_size(
+    let buffer_size = crate::utils::system::compute_buffer_size(
         config,
-        "fanout",
+        "fanout_to_channels",
         data_type,
-        1.45,
+        1.5, // slightly higher multiplier than normal paths because we duplicate
     );
 
     let mut txs: Vec<mpsc::Sender<ParseOutput>> = Vec::with_capacity(n_branches);
     let mut rxs = Vec::with_capacity(n_branches);
 
     for _ in 0..n_branches {
-        let (tx, rx) = mpsc::channel(buffer_per_branch);
+        let (tx, rx) = mpsc::channel(buffer_size);
         txs.push(tx);
         rxs.push(rx);
     }
 
     let label = label.to_string();
+    let (done_tx, done_rx) = oneshot::channel::<Result<(), anyhow::Error>>();
 
-    let router = tokio::spawn(async move {
-        let mut count = 0usize;
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+
+        let mut item_count: usize = 0;
+        let mut last_progress = Instant::now();
 
         while let Some(item) = upstream.next().await {
-            count += 1;
+            item_count += 1;
 
-            for (branch_idx, tx) in txs.iter().enumerate() {
-                if tx.send(item.clone()).await.is_err() {
-                    return Err(anyhow!(
-                        "[fanout {}] branch {} closed unexpectedly while upstream was still producing (after {} items)",
-                        label, branch_idx, count
-                    ));
+            // Track slowest branch for backpressure (prevents router from buffering forever)
+            let mut lowest_capacity = 1.0f64;
+
+            for (i, tx) in txs.iter().enumerate() {
+                let cap_ratio = tx.capacity() as f64 / buffer_size as f64;
+                lowest_capacity = lowest_capacity.min(cap_ratio);
+
+                match tx.try_send(item.clone()) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        if tx.send(item.clone()).await.is_err() {
+                            let _ = done_tx.send(Err(anyhow!(
+                                "[fanout {}] branch {} dropped while upstream still producing (after {} items)",
+                                label, i, item_count
+                            )));
+                            return;
+                        }
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        let _ = done_tx.send(Err(anyhow!(
+                            "[fanout {}] branch {} closed unexpectedly while upstream still producing (after {} items)",
+                            label, i, item_count
+                        )));
+                        return;
+                    }
                 }
+            }
+
+            // Smart backpressure — only slow down when the slowest branch is getting full
+            if lowest_capacity < 0.10 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            } else if lowest_capacity < 0.25 {
+                tokio::task::yield_now().await;
+            }
+
+            // Occasional progress for very long streams (cheap)
+            if item_count % 50_000 == 0 && last_progress.elapsed() > Duration::from_secs(30) {
+                debug!("[fanout {}] forwarded {} items so far", label, item_count);
+                last_progress = Instant::now();
             }
         }
 
-        debug!("[fanout {}] finished cleanly — forwarded {} items total", label, count);
-        Ok(())
+        // Upstream ended (including the 0-item case). Drop all senders so branches see EOF.
+        drop(txs);
+
+        debug!("[fanout {}] finished cleanly — forwarded {} items to {} branches", label, item_count, n_branches);
+        let _ = done_tx.send(Ok(()));
     });
 
-    Ok((rxs, router))
+    Ok((rxs, done_rx))
 }
 
 #[cfg(test)]

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use log::{self, LevelFilter, debug, info, error, warn};
 use futures::StreamExt;
 use sysinfo::{System, Pid, ProcessesToUpdate};
-use seqtoid_pipelines::utils::streams::{read_child_output_to_vec, stream_to_cmd, t_junction, parse_child_output, stream_to_file, ChildStream, ParseMode, ParseOutput, deinterleave_fastq_stream_to_fifos};
+use seqtoid_pipelines::utils::streams::{read_child_output_to_vec, stream_to_cmd, parse_child_output, stream_to_file, ChildStream, ParseMode, ParseOutput, deinterleave_fastq_stream_to_fifos, fanout_to_channels};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio::process::{Child, Command};
@@ -191,184 +191,150 @@ fn create_test_run_config() -> Arc<RunConfig> {
 
 
 #[tokio::test]
-async fn test_t_junction_stress() -> Result<()> {
-    let buffer_sizes = [1000, 10_000, 100_000];
-    let stall_thresholds = [100, 1000];
-    let sleep_ms_options = [Some(0), Some(10)];
-    let backpressure_pause_ms_options = [50, 500];
-    let num_reads = 100_000;
+async fn test_fanout_to_channels_stress() -> Result<()> {
+    let num_reads_options = [10_000, 100_000];
+    let n_outputs_options = [2, 4];
     let seq_len = 100;
-    let n_outputs = 2;
-    let mut log = std::fs::File::create("t_junction_stress.log")?;
+    let config = create_test_run_config();
+
+    let mut log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("fanout_stress.log")?;
+
     writeln!(
         &mut log,
-        "BufferSize\tStall\tSleep\tBackpressurePause\tStreams\tReads\tSeqLen\tTime\tMemory\tRecords\tSuccess"
+        "Streams\tReads\tSeqLen\tTime\tRecords\tSuccess"
     )?;
 
-    for &buffer_size in &buffer_sizes {
-        for &stall_threshold in &stall_thresholds {
-            for &sleep_ms in &sleep_ms_options {
-                for &backpressure_pause_ms in &backpressure_pause_ms_options {
-                    info!(
-                        "Buffer size: {}  Stall: {}  Sleep: {}  Pause: {}  Streams: {} Reads: {}  Size: {}",
-                        buffer_size,
-                        stall_threshold,
-                        sleep_ms.unwrap_or(0),
-                        backpressure_pause_ms,
-                        n_outputs,
-                        num_reads,
-                        seq_len
-                    );
+    for &num_reads in &num_reads_options {
+        for &n_outputs in &n_outputs_options {
+            info!(
+                "Testing fanout_to_channels: Streams: {} Reads: {}  Size: {}",
+                n_outputs,
+                num_reads,
+                seq_len
+            );
 
-                    let stream = fastx_generator(num_reads, seq_len, 30.0, 5.0).map(ParseOutput::Fastq);
-                    let start = Instant::now();
-                    let (outputs, done_rx) = t_junction(
-                        stream,
-                        n_outputs,
-                        buffer_size,
-                        stall_threshold,
-                        sleep_ms,
-                        backpressure_pause_ms,
-                        StreamDataType::IlluminaFastq,
-                        "t_junction_stress".to_string(),
-                        None
-                    )
-                        .await?;
+            let stream = fastx_generator(num_reads, seq_len, 30.0, 5.0).map(ParseOutput::Fastq);
+            let start = Instant::now();
+            
+            // Re-creating the stream because fanout_to_channels takes ownership of ReceiverStream
+            let (tx, rx) = mpsc::channel(1000);
+            let stream_input = ReceiverStream::new(rx);
+            
+            let (outputs, router_handle) = fanout_to_channels(
+                stream_input,
+                n_outputs,
+                "fanout_stress",
+                &config,
+                StreamDataType::IlluminaFastq
+            ).await?;
 
-                    let mut run_success = true;
-                    let record_counts = Arc::new(Mutex::new(vec![0; n_outputs]));
-                    let mut handles = Vec::new();
+            let record_counts = Arc::new(Mutex::new(vec![0; n_outputs]));
+            let mut handles = Vec::new();
 
-                    for (i, rx) in outputs.into_iter().enumerate() {
-                        let record_counts = Arc::clone(&record_counts);
-                        let handle = tokio::spawn(async move {
-                            let mut stream = ReceiverStream::new(rx);
-                            while let Some(_item) = stream.next().await {
-                                let mut counts = record_counts.lock().unwrap();
-                                counts[i] += 1;
-                                if counts[i] % 1000 == 0 {
-                                    info!("Stream {} processed {} items", i, counts[i]);
-                                }
-                            }
-                        });
-                        handles.push(handle);
+            for (i, rx) in outputs.into_iter().enumerate() {
+                let record_counts = Arc::clone(&record_counts);
+                let handle = tokio::spawn(async move {
+                    let mut stream = ReceiverStream::new(rx);
+                    while let Some(_item) = stream.next().await {
+                        let mut counts = record_counts.lock().unwrap();
+                        counts[i] += 1;
                     }
-
-                    join_all(handles).await;
-
-                    match done_rx.await {
-                        Ok(result) => match result {
-                            Ok(()) => info!("t_junction completed successfully"),
-                            Err(e) => {
-                                error!("t_junction failed: {}", e);
-                                run_success = false;
-                            }
-                        },
-                        Err(e) => {
-                            error!("t_junction task failed to send: {}", e);
-                            run_success = false;
-                        }
-                    }
-
-                    let duration = start.elapsed();
-                    let memory = 0; // Update with sysinfo if enabled
-                    let record_counts = record_counts.lock().unwrap();
-                    info!(
-                        "Records: {:?}  Success: {}",
-                        *record_counts, run_success
-                    );
-                    writeln!(
-                        &mut log,
-                        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}",
-                        buffer_size,
-                        stall_threshold,
-                        sleep_ms.unwrap_or(0),
-                        backpressure_pause_ms,
-                        n_outputs,
-                        num_reads,
-                        seq_len,
-                        duration.as_secs_f64(),
-                        memory,
-                        *record_counts,
-                        run_success
-                    )?;
-
-                    assert_eq!(
-                        *record_counts,
-                        vec![num_reads; n_outputs],
-                        "Incorrect record counts"
-                    );
-                }
+                });
+                handles.push(handle);
             }
+
+            // Feed the input
+            let mut input_gen = fastx_generator(num_reads, seq_len, 30.0, 5.0).map(ParseOutput::Fastq);
+            while let Some(item) = input_gen.next().await {
+                tx.send(item).await.map_err(|e| anyhow!("Failed to send to fanout: {}", e))?;
+            }
+            drop(tx);
+
+            join_all(handles).await;
+            router_handle.await??;
+
+            let duration = start.elapsed();
+            let record_counts_final = record_counts.lock().unwrap().clone();
+            let run_success = record_counts_final == vec![num_reads; n_outputs];
+            
+            info!(
+                "Records: {:?}  Success: {}",
+                record_counts_final, run_success
+            );
+            writeln!(
+                &mut log,
+                "{}\t{}\t{}\t{}\t{:?}\t{}",
+                n_outputs,
+                num_reads,
+                seq_len,
+                duration.as_secs_f64(),
+                record_counts_final,
+                run_success
+            )?;
+
+            assert!(run_success, "Incorrect record counts: expected {}, got {:?}", num_reads, record_counts_final);
         }
     }
     Ok(())
 }
 
 #[tokio::test]
-async fn test_t_junction_count() -> Result<()> {
+async fn test_fanout_to_channels_count() -> Result<()> {
     let num_read = 10_000;
     let read_size = 50;
-    let buffer_size = 100_000;
-    let stall_threshold = 100;
-    let sleep_ms = Some(1);
-    let backpressure_pause_ms = 500;
-    info!(
-        "Testing t_junction: Reads: {}, Size: {}, Buffer: {}, Sleep: {:?}",
-        num_read, read_size, buffer_size, sleep_ms
-    );
-    stderr().flush()?;
-    let stream = fastx_generator(num_read, read_size, 35.0, 3.0).map(ParseOutput::Fastq);
-    let (outputs, done_rx) = t_junction(
-        stream,
-        2,
-        buffer_size,
-        stall_threshold,
-        sleep_ms,
-        backpressure_pause_ms,
-        StreamDataType::IlluminaFastq,
-        "t_junction_count".to_string(),
-        None
-    ).await?;
-    let mut counts = vec![0usize; 2];
-    let mut handles = Vec::new();
+    let n_outputs = 2;
+    let config = create_test_run_config();
 
+    info!(
+        "Testing fanout_to_channels_count: Reads: {}, Size: {}, Streams: {}",
+        num_read, read_size, n_outputs
+    );
+
+    let (tx, rx) = mpsc::channel(1000);
+    let stream_input = ReceiverStream::new(rx);
+
+    let (outputs, router_handle) = fanout_to_channels(
+        stream_input,
+        n_outputs,
+        "fanout_count",
+        &config,
+        StreamDataType::IlluminaFastq
+    ).await?;
+
+    let mut handles = Vec::new();
     for (i, rx) in outputs.into_iter().enumerate() {
         let handle = tokio::spawn(async move {
             let mut stream = ReceiverStream::new(rx);
             let mut count = 0;
             while let Some(_) = stream.next().await {
                 count += 1;
-                if count % 1000 == 0 {
-                    info!("t_junction stream {} counted {} records", i, count);
-                    stderr().flush().ok();
-                }
             }
-            info!("t_junction stream {} finished: {} records", i, count);
-            Ok::<_, anyhow::Error>(count)
+            info!("fanout stream {} finished: {} records", i, count);
+            Ok::<usize, anyhow::Error>(count)
         });
-        handles.push((i, handle));
+        handles.push(handle);
     }
 
-    for (i, handle) in handles {
-        counts[i] = handle.await??;
+    // Feed input
+    let mut input_gen = fastx_generator(num_read, read_size, 35.0, 3.0).map(ParseOutput::Fastq);
+    while let Some(item) = input_gen.next().await {
+        tx.send(item).await?;
+    }
+    drop(tx);
+
+    let mut counts = Vec::new();
+    for handle in handles {
+        counts.push(handle.await??);
     }
 
-    match done_rx.await {
-        Ok(Ok(())) => info!("t_junction completed successfully"),
-        Ok(Err(e)) => error!("t_junction failed: {}", e),
-        Err(e) => error!("t_junction send error: {}", e),
-    }
-    stderr().flush()?;
-    info!("t_junction counts: {:?}", counts);
-    stderr().flush()?;
-    if counts != vec![num_read, num_read] {
-        return Err(anyhow!(
-            "t_junction produced [{:}], expected [{}, {}]",
-            counts.iter().map(|c| c.to_string()).collect::<Vec<_>>().join(", "),
-            num_read, num_read
-        ));
-    }
+    router_handle.await??;
+
+    info!("fanout counts: {:?}", counts);
+    assert_eq!(counts, vec![num_read; n_outputs]);
+    
     Ok(())
 }
 
@@ -385,18 +351,23 @@ async fn test_stream_to_cmd_direct() -> Result<()> {
     );
     stderr().flush()?;
 
-    let stream = fastx_generator(num_read, read_size, 35.0, 3.0).map(ParseOutput::Fastq);
-    let (mut outputs, done_rx) = t_junction(
-        stream,
+    let (tx, rx) = mpsc::channel(1000);
+    let stream_input = ReceiverStream::new(rx);
+    let (mut outputs, done_rx) = fanout_to_channels(
+        stream_input,
         1,
-        100_000,
-        100,
-        Some(1),
-        500,
-        StreamDataType::IlluminaFastq,
-        "test_stream_to_cmd_direct".to_string(),
-        None
+        "test_stream_to_cmd_direct",
+        &config,
+        StreamDataType::IlluminaFastq
     ).await?;
+
+    // Feed input in a background task to avoid blocking
+    tokio::spawn(async move {
+        let mut stream = fastx_generator(num_read, read_size, 35.0, 3.0).map(ParseOutput::Fastq);
+        while let Some(item) = stream.next().await {
+            let _ = tx.send(item).await;
+        }
+    });
 
     let rx = outputs.pop().ok_or_else(|| anyhow!("No output stream"))?;
     let (child, inner_task, _inner_err_task) = stream_to_cmd(
@@ -487,33 +458,35 @@ async fn test_stream_to_cmd_stress() -> Result<()> {
                                 );
                                 stderr().flush()?;
 
-                                // Generate stream and split with t_junction
-                                let stream = fastx_generator(*num_read, *read_size, 35.0, 3.0).map(ParseOutput::Fastq);
-                                let mut gen_count = 0;
-                                let stream = stream.inspect(move |_result| {
-                                    gen_count += 1;
-                                });
-                                let (outputs, done_rx) = match t_junction(
-                                    stream,
+                                // Generate stream and fan out
+                                let (tx, rx) = mpsc::channel(1000);
+                                let stream_input = ReceiverStream::new(rx);
+                                let (outputs, done_rx) = match fanout_to_channels(
+                                    stream_input,
                                     *stream_num,
-                                    *buffer_size,
-                                    10000,
-                                    if *sleep == 0 { None } else { Some(*sleep) },
-                                    backpressure_pause_ms,
+                                    "test_stream_to_cmd_stress",
+                                    &config,
                                     StreamDataType::IlluminaFastq,
-                                    "test_stream_to_cmd_stress".to_string(),
-                                    None
-
                                 )
                                     .await {
                                     Ok(result) => result,
                                     Err(e) => {
-                                        error!("t_junction failed to start: {}", e);
+                                        error!("fanout_to_channels failed to start: {}", e);
                                         run_success = false;
-                                        return Err(anyhow!("t_junction failed: {}", e));
+                                        return Err(anyhow!("fanout_to_channels failed: {}", e));
                                     }
                                 };
-                                info!("t_junction started with {} streams", *stream_num);
+                                info!("fanout_to_channels started with {} streams", *stream_num);
+
+                                // Feed input in a background task
+                                let num_read_val = *num_read;
+                                let read_size_val = *read_size;
+                                tokio::spawn(async move {
+                                    let mut stream = fastx_generator(num_read_val, read_size_val, 35.0, 3.0).map(ParseOutput::Fastq);
+                                    while let Some(item) = stream.next().await {
+                                        let _ = tx.send(item).await;
+                                    }
+                                });
                                 stderr().flush()?;
 
                                 let mut tasks: Vec<JoinHandle<Result<(), anyhow::Error>>> = Vec::new();
@@ -571,7 +544,7 @@ async fn test_stream_to_cmd_stress() -> Result<()> {
                                     result??; // Unwrap JoinHandle and inner Result, propagating errors
                                 }
 
-                                done_rx.await??; // Propagates any t_junction errors
+                                done_rx.await??; // Propagates any fanout errors
 
                                 for outfile in &outfiles {
                                     let mut cmd = String::new();
@@ -645,7 +618,7 @@ async fn test_stream_to_cmd_stress() -> Result<()> {
 
                                 if !run_success {
                                     return Err(anyhow!(
-                                        "Test failed due to errors in stream_to_cmd or t_junction"
+                                        "Test failed due to errors in stream_to_cmd or fanout_to_channels"
                                     ));
                                 }
                             }


### PR DESCRIPTION
full replacement of old t-junction stream splitter with new fanout-to-channels with better back pressure handling.  More careful placement of done one shots in pipelines to await when all branches of a fanout complete but not later than that. Better handling of zero data streams and noisier guarantees of "never silently drop data".